### PR TITLE
Drop skill-owned tables on delete

### DIFF
--- a/skills/skill_creator.py
+++ b/skills/skill_creator.py
@@ -828,6 +828,8 @@ def _delete_skill(skill_name: str) -> str:
     if not target.exists():
         return f"Error: skill '{skill_name}' not found in {user_dir}"
 
+    dropped_tables = _drop_skill_owned_tables(skill_name, target)
+
     # Disable first
     disable(skill_name)
 
@@ -842,7 +844,59 @@ def _delete_skill(skill_name: str) -> str:
         for cached in pycache.glob(f"{skill_name}*"):
             cached.unlink(missing_ok=True)
 
+    if dropped_tables:
+        return f"Deleted skill '{skill_name}' ({dropped_tables} skill table(s) dropped)"
     return f"Deleted skill '{skill_name}'"
+
+
+def _drop_skill_owned_tables(skill_name: str, skill_path: Path) -> int:
+    """Drop SQLite tables declared by this skill's own namespaced DDL."""
+    try:
+        source = skill_path.read_text(encoding="utf-8")
+        tables = _extract_skill_owned_tables(source, skill_name)
+        if not tables:
+            return 0
+
+        import db
+
+        conn = db._get_conn()
+        dropped = 0
+        for table in tables:
+            exists = conn.execute(
+                "SELECT 1 FROM sqlite_master WHERE type='table' AND name=?",
+                (table,),
+            ).fetchone()
+            if not exists:
+                continue
+            conn.execute(f'DROP TABLE IF EXISTS "{table}"')
+            dropped += 1
+        if dropped:
+            conn.commit()
+        return dropped
+    except Exception as e:
+        import logger
+
+        logger.get("skill_creator").warning(
+            f"failed to clean tables for {skill_name}: {e}"
+        )
+        return 0
+
+
+def _extract_skill_owned_tables(source: str, skill_name: str) -> list[str]:
+    """Return safe table names with the skill_<skill_name>_ prefix."""
+    prefix = f"skill_{skill_name}_"
+    pattern = re.compile(
+        r"CREATE\s+TABLE(?:\s+IF\s+NOT\s+EXISTS)?\s+[`\"'\[]?"
+        r"([A-Za-z_][A-Za-z0-9_]*)"
+        r"[`\"'\]]?",
+        re.IGNORECASE,
+    )
+    tables = {
+        table
+        for table in pattern.findall(source)
+        if table.startswith(prefix) and table.isidentifier()
+    }
+    return sorted(tables)
 
 
 def _create_skill_async(skill_name: str, description: str) -> str:

--- a/tests/test_skill_creator_smoke.py
+++ b/tests/test_skill_creator_smoke.py
@@ -210,6 +210,65 @@ def test_delete_skill_missing_returns_friendly_error(sc):
     assert "not found" in result.lower()
 
 
+def test_delete_skill_drops_only_owned_namespaced_tables(sc, qwe_temp_data_dir):
+    import db
+
+    target = qwe_temp_data_dir / "skills" / "cleanup_demo.py"
+    target.parent.mkdir(parents=True, exist_ok=True)
+    target.write_text(
+        '''
+def execute(name, args):
+    conn.execute("""CREATE TABLE IF NOT EXISTS skill_cleanup_demo_items (
+        id INTEGER PRIMARY KEY,
+        body TEXT
+    )""")
+    conn.execute("""CREATE TABLE IF NOT EXISTS skill_cleanup_demo_events (
+        id INTEGER PRIMARY KEY,
+        body TEXT
+    )""")
+    conn.execute("""CREATE TABLE IF NOT EXISTS shared_items (
+        id INTEGER PRIMARY KEY
+    )""")
+''',
+        encoding="utf-8",
+    )
+
+    conn = db._get_conn()
+    conn.execute("CREATE TABLE skill_cleanup_demo_items (id INTEGER PRIMARY KEY)")
+    conn.execute("CREATE TABLE skill_cleanup_demo_events (id INTEGER PRIMARY KEY)")
+    conn.execute("CREATE TABLE shared_items (id INTEGER PRIMARY KEY)")
+    conn.commit()
+
+    result = sc._delete_skill("cleanup_demo")
+
+    assert "Deleted skill 'cleanup_demo'" in result
+    assert "2 skill table(s) dropped" in result
+    assert not target.exists()
+    assert conn.execute(
+        "SELECT name FROM sqlite_master WHERE type='table' AND name='skill_cleanup_demo_items'"
+    ).fetchone() is None
+    assert conn.execute(
+        "SELECT name FROM sqlite_master WHERE type='table' AND name='skill_cleanup_demo_events'"
+    ).fetchone() is None
+    assert conn.execute(
+        "SELECT name FROM sqlite_master WHERE type='table' AND name='shared_items'"
+    ).fetchone() is not None
+
+
+def test_extract_skill_owned_tables_ignores_other_skill_prefixes(sc):
+    source = '''
+conn.execute("""CREATE TABLE IF NOT EXISTS skill_notes_data (id INTEGER)""")
+conn.execute("""CREATE TABLE IF NOT EXISTS skill_notes_archive (id INTEGER)""")
+conn.execute("""CREATE TABLE IF NOT EXISTS skill_notes2_data (id INTEGER)""")
+conn.execute("""CREATE TABLE IF NOT EXISTS notes (id INTEGER)""")
+'''
+
+    assert sc._extract_skill_owned_tables(source, "notes") == [
+        "skill_notes_archive",
+        "skill_notes_data",
+    ]
+
+
 # ── execute() dispatch ───────────────────────────────────────────────
 
 


### PR DESCRIPTION
﻿## Summary

Drop namespaced SQLite tables declared by a user-created skill before deleting its `.py` file, so `delete_skill()` does not leave `skill_<name>_*` tables orphaned.

Fixes #15.

## Test plan

- [x] `python -m pytest tests\test_skill_creator_smoke.py -q -k "delete_skill or extract_skill_owned"` -> 5 passed
- [x] `python -m pytest tests\test_skill_creator_smoke.py -q -k "not tool_search"` -> 26 passed, 1 deselected
- [x] `python -m py_compile skills\skill_creator.py tests\test_skill_creator_smoke.py`
- [ ] `python -m ruff check skills\skill_creator.py tests\test_skill_creator_smoke.py` -> local env has no `ruff` module
- [ ] `python -m pytest tests\test_skill_creator_smoke.py -q` -> local env is missing `qdrant_client`, so the existing `tool_search` import path cannot load `memory`

## Before merging

- [ ] `ruff check .` passes
- [ ] `pytest tests/` passes
- [ ] If you touched `static/index.html`: `python scripts/check_js.py` passes
- [ ] If you added a new top-level module: it's listed in `pyproject.toml` `[tool.setuptools] py-modules`
- [ ] If you added a new setting: it's in `config.py` `EDITABLE_SETTINGS` with a description
- [x] If you changed behaviour: updated relevant tests (not just added new ones)
- [x] I've read [CONTRIBUTING.md](../blob/main/CONTRIBUTING.md)

## Notes for reviewer

The cleanup is deliberately conservative: it only extracts safe identifier table names from `CREATE TABLE` statements that match the deleted skill's `skill_<skill_name>_*` prefix, verifies each name in `sqlite_master`, and then drops only those tables. Non-namespaced tables are left alone.
