### PR TITLE
docs(CLAUDE.md): refresh for v0.18.x

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -15,9 +15,10 @@ python cli.py --web --ssl --port 7861        # Web UI (HTTPS required for mic/ca
 qwe-qwe --web --doctor                       # If installed as package; doctor runs 30+ checks
 
 # Tests
-pytest tests/                                # All tests (186 currently)
+pytest tests/                                # All tests (~495 currently)
 pytest tests/test_integration.py -v          # Integration tests (TestClient + mocked LLM)
 pytest tests/test_turn_context.py -v         # Per-request state isolation
+pytest tests/test_telemetry.py -v            # Privacy contract + consent gates
 pytest tests/test_tools.py::test_blocks_sudo # Single test by nodeid
 pytest --cov --cov-report=term               # With coverage (floor: 24% — do not regress)
 
@@ -114,16 +115,55 @@ When adding new per-turn state: put it on TurnContext, not as a module global.
 - **Rule 8** MEMORY DISCIPLINE (v0.17.12) — default is DON'T save; only durable facts that matter weeks later
 - **Rule 11** Brave Search for web (Google/DuckDuckGo block headless)
 - **Rule 12** After `write_file`, call `send_file`
+- **Rule 14** NEW INTEGRATION (v0.18.x) — for service integrations (Gmail, Slack, custom skills) call `create_skill`, never `write_file` in skills/. After `create_skill` invocation: **STOP the turn**, don't run more tools — pipeline is async, notification fires later. Skills are single .py files, never directories.
+- **Rule 16** EXTERNAL-WAIT (v0.18.x) — for browser OAuth / 2FA / hardware-key / email-confirm flows: don't run blocking commands (shell tool times out at 120s). Use `--no-launch-browser` / `--device-code` flags, surface URL via `open_url`, end the turn, resume on user's next message.
 
 ### Providers (`providers.py`)
 
-OpenAI-compatible client for 7 providers (lmstudio, ollama, openai, openrouter, groq, together, deepseek). `list_all()` pings local providers in parallel (1s timeout, 30s cache). `detect_context_length()` probes LM Studio `/api/v0/models` or Ollama `/api/show` to discover the real context window (displayed in the Web UI Context Window gauge — denominator is `context_budget`, shown alongside the detected model_context).
+OpenAI-compatible client for 10 providers (lmstudio, ollama, openai, openrouter, groq, together, deepseek + perplexity / cerebras / mistral added in v0.17.33). `list_all()` pings local providers in parallel (1s timeout, 30s cache). `detect_context_length()` probes LM Studio `/api/v0/models` or Ollama `/api/show` to discover the real context window (displayed in the Web UI Context Window gauge — denominator is `context_budget`, shown alongside the detected model_context).
+
+### Skill Creator (`skills/skill_creator.py`)
+
+User can chat-create new skills: "build me a meal logger that takes a photo and remembers what I ate" → `tool_search("skill")` → `create_skill(name, description)` → 5-step LLM pipeline writes a `.py` to `~/.qwe-qwe/skills/<name>.py`.
+
+Pipeline phases (`_run_pipeline`, runs in background thread, 3 retry attempts):
+1. **Plan** — JSON of `{docstring, instruction, tables, tools}`. Plan prompt instructs the planner to compose with the full agent runtime (memory.save, tools.execute("camera_capture"), secrets, http_request).
+2. **Tool definitions** — JSON array of OpenAI function schemas.
+3. **Mapping + assembly** — `_assemble_from_mapping()` recognises CRUD ops (add/list/delete/update/get/stats) and emits Python from templates without an LLM call. Custom ops fall through to a STEP3_CODE LLM call. **First branch must be `if`, not `elif`** when execute_body is empty — `_run_pipeline` instructs the LLM accordingly AND post-processes the output via regex (defense-in-depth, fixed in v0.18.3).
+4. **Table DDL** — `_build_table_ddl(plan)`. **Tables MUST be prefixed `skill_<name>_*`** to avoid collisions with core agent tables (messages, kv, threads) and other skills' tables. Documented in INSTRUCTION + STEP1_PLAN, enforced by tests.
+5. **Validate + smoke** — ast.parse, then `validate_skill()`, then `_smoke_test()` calls `execute()` for each declared tool. **Param-usage check (v0.18.4)** scopes search to `execute()` body via AST, no longer false-matches param names appearing in the TOOLS dict literal.
+
+Soul rule 14 (v0.18.x): when user requests a service integration, agent calls `create_skill` and **STOPS the turn** — no parallel `write_file` to skills/, no manual scaffolding. Skills are SINGLE `.py` files at `~/.qwe-qwe/skills/<name>.py`, never directories.
+
+`delete_skill(name)` parses CREATE TABLE statements, drops only `skill_<name>_*` matches via `_extract_skill_owned_tables` (regex with isidentifier guard), then unlinks the .py.
+
+### Telemetry (`telemetry.py`) — opt-in, anonymous, audit-friendly
+
+**Default OFF.** No data leaves the machine until the user explicitly opts in via the first-run modal (web) / TTY prompt (CLI) / Settings → Privacy → Telemetry.
+
+Privacy contract (enforced at `track_event()`):
+- 5 whitelisted events (`session_start`, `turn_complete`, `tool_error`, `skill_creator_pipeline`, `feature_first_use`) with type-strict prop schemas.
+- String props that could carry free text use closed enums (`TOOL_CATEGORIES`, `ERROR_KINDS`, `SOURCES`, `PROVIDER_KINDS`, `MODEL_SIZE_BUCKETS`, `PIPELINE_OUTCOMES`, `FEATURES`). A future refactor adding a string field can't smuggle chat content past the validator.
+- Anonymous_id is a random UUID generated on first opt-in. Not derived from any PII. `forget_me()` wipes; `reset_anonymous_id()` rotates without disabling.
+- Two consent gates (`track_event` + `flush`) refuse to accept / send when `consent_needs_reprompt()` is True.
+
+Wire formats (`telemetry.py::_default_sender` dispatches by `telemetry_format`):
+- `raw` — single batched POST `{"events": [...]}` for custom collectors.
+- `countly` — batched POST to Countly's `/i` with `device_id = anonymous_id` (cross-day per-user tracking works natively, unlike Plausible's daily-rotating salt). Lists become CSV strings; `duration_ms` becomes Countly `dur` (seconds).
+
+Project defaults ship the Countly path pointing at `https://qwelytics.deepfounder.ai/i` with the project's public Countly app key. End-user UI surfaces only Enable/Disable + transparency lists — endpoint / format / app_key are NOT user-editable (operators / forks edit `config.py` defaults).
+
+Consent versioning (`_CURRENT_CONSENT_VERSION` constant in `telemetry.py`): bump when `ALLOWED_EVENTS` shape changes OR default endpoint changes. Old consent → "policy updated, please re-confirm" banner; events queue but don't send until user re-stamps via opt_in.
+
+Adding a new event: edit `ALLOWED_EVENTS` schema + bump `_CURRENT_CONSENT_VERSION`. Audit by grep `telemetry.track_event` — only path into the queue.
+
+Full data inventory + privacy contract: `docs/PRIVACY.md`.
 
 ### Voice / Camera / Knowledge ingest
 
 - **STT** (`stt.py`): auto/local/api; local = faster-whisper on CPU; API = OpenAI-compatible (Groq free tier works). PyAV fallback when ffmpeg missing.
 - **TTS** (`tts.py`): auto-detects API style (OpenAI `/v1/audio/speech`, custom `/tts` w/ voice cloning, Fish Speech, s2.cpp).
-- **Camera**: `camera_capture(prompt?)` grabs frame via WebSocket (browser) or OpenCV (direct). Persistent `_camera_cap` for fast repeat captures.
+- **Camera**: `camera_capture(prompt?)` grabs frame via WebSocket (browser) or OpenCV (direct). Persistent `_camera_cap` for fast repeat captures. WS event names unified `get_frame` / `frame_request` (v0.18.2). Client falls back to one-shot `getUserMedia` when PiP isn't active. OpenCV path has black-frame guard (mean<25 → up to 30 retries, sensor warmup) for Windows DirectShow gotchas. Auto-detect picks BRIGHTEST of indexes 0-3, not first non-pitch-black. Resolution + JPEG quality user-tunable via `camera_resolution` (auto/480p/720p/1080p) + `camera_quality` (1-100) settings.
 - **URL/file indexing** (`rag.py`): MarkItDown handles PDF/DOCX/PPTX/XLSX/HTML/etc. YouTube-specific path uses `yt-dlp` with `player_client=["android","ios","web"]` to dodge DRM blocks, native-language preferred over auto-translated English.
 - **SSRF** (v0.17.18): `/api/knowledge/url` blocks private/loopback/link-local IPs unless `QWE_ALLOW_PRIVATE_URLS=1`. Uses `socket.getaddrinfo` + `ipaddress.ip_address.is_private`.
 
@@ -170,7 +210,7 @@ Render pattern: every state change rebuilds innerHTML. Event handlers attached v
 
 ## Tests (`tests/`)
 
-All 186 tests run in a single pytest process (v0.17.24 — no more sys.modules pollution). Do NOT add `sys.modules[...] = mock_X` at module scope — use `monkeypatch` fixtures (see `tests/conftest.py` for `qwe_temp_data_dir`, `mock_llm`).
+All ~495 tests run in a single pytest process (v0.17.24 — no more sys.modules pollution). Do NOT add `sys.modules[...] = mock_X` at module scope — use `monkeypatch` fixtures (see `tests/conftest.py` for `qwe_temp_data_dir`, `mock_llm`).
 
 Notable files:
 - `test_integration.py` — TestClient + mocked LLM end-to-end (added to catch v0.17.23-style lazy-import SyntaxErrors)
@@ -178,9 +218,15 @@ Notable files:
 - `test_shell_safety.py` — obfuscation bypass catalog (39 cases)
 - `test_secret_scrub.py` — regex patterns for API key shapes
 - `test_migrations.py` — fresh + back-compat + idempotent + rollback
+- `test_skill_creator_smoke.py` + `test_skill_creator_pipeline.py` — pure helpers + e2e pipeline with mocked LLM (camera-using skill regression test)
+- `test_telemetry.py` — privacy contract + Countly + raw + consent gates (~58 tests)
+- `test_text_to_tool_extraction.py` — all 5 patterns including the `!<function_call:>` Qwen variant (#10)
+- `test_camera_settings.py` — preset table + helper, `pytest.importorskip("cv2")` for CI
 - `conftest.py` — shared fixtures; `scope="session"` TestClient lives here
 
-Coverage baseline 25.93%; floor 24% (`pyproject.toml::tool.coverage.report.fail_under`). 0% modules (`cli.py`, `inference_setup.py`, `synthesis.py`, `skills/browser.py`) are candidates for future integration tests.
+Coverage baseline 25.93%; floor 24% (`pyproject.toml::tool.coverage.report.fail_under`). Some modules under 10% (`cli.py`, `inference_setup.py`, `synthesis.py`) are candidates for future integration tests.
+
+CI flake to know about: `tests/test_telemetry_wireup.py::test_tool_error_classifies_keyboard_interrupt_as_aborted` sometimes fails in full-suite collection (KeyboardInterrupt is special-cased by pytest); always passes in isolation.
 
 ## Data layout (`~/.qwe-qwe/` — override via `QWE_DATA_DIR`)
 
@@ -208,13 +254,17 @@ Coverage baseline 25.93%; floor 24% (`pyproject.toml::tool.coverage.report.fail_
 | `QWE_EMBED_DEVICE` | `cpu` | FastEmbed provider — CPU by design (v0.17.21). Set `cuda` only if you've installed `onnxruntime-gpu` + matching CUDA Toolkit manually. |
 | `QWE_ALLOW_PRIVATE_URLS` | unset | Set to `1` to bypass SSRF block on `/api/knowledge/url` (dev only). |
 
+Telemetry-related settings live in `EDITABLE_SETTINGS` (not env vars): `telemetry_enabled` (default 0), `telemetry_endpoint` (default `https://qwelytics.deepfounder.ai/i`), `telemetry_format` (`raw` / `countly`, default `countly`), `telemetry_countly_app_key`, `telemetry_anonymous_id`, `telemetry_consent_version`. Operators / forks edit defaults in `config.py`; end-users only see Enable/Disable.
+
 ## When adding a feature — quick checklist
 
 1. **New .py module?** Add to `[tool.setuptools] py-modules` in `pyproject.toml` (else `pip install -e .` crashes on import for downstream installs).
-2. **New tool?** Add to `tools.TOOLS` list + branch in `tools.execute()`. If it takes a `path` arg, call `_get_path_arg(args)` (models use various field names). If it's dangerous (writes, shells), it must pass `_pre_dispatch_safety_check`.
+2. **New tool?** Add to `tools.TOOLS` list + branch in `tools.execute()`. If it takes a `path` arg, call `_get_path_arg(args)` (models use various field names). If it's dangerous (writes, shells), it must pass `_pre_dispatch_safety_check`. Also map the new tool name to a category in `tools.TOOL_CATEGORIES_BY_NAME` so telemetry events bucket correctly.
 3. **New per-turn state?** Put on `TurnContext`, not as a module global.
 4. **New setting?** Add to `EDITABLE_SETTINGS` in `config.py` with `(kv_key, type, default, desc, min, max)`. `config.get("foo")` reads with defaults.
 5. **New schema change?** New file `migrations/NNN_snake_case.sql`. `_apply_migrations()` picks it up.
 6. **New doctor check?** Add to `cli.py:doctor()`. Must survive cp1251 terminals — no raw emoji in output.
-7. **New WS event?** Emit via `ctx.on_*` callback, not a global. Client reads in `handleWSMessage` in `static/index.html`.
-8. **Before commit**: `ruff check .`, `python scripts/check_js.py` (if you touched `static/index.html`), `pytest tests/`.
+7. **New WS event?** Emit via `ctx.on_*` callback, not a global. Client reads in `handleWSMessage` in `static/index.html`. If event is non-chat (notification / status / etc.), short-circuit at the top of `handleWsMessage` BEFORE the `state.streaming` creation gate — otherwise it triggers a ghost streaming message in the chat (lesson from `task_update` bug, fixed in v0.18.3).
+8. **New telemetry event?** Add to `telemetry.ALLOWED_EVENTS` whitelist with type-strict prop schema. String props that could carry free text MUST use a closed enum. Bump `telemetry._CURRENT_CONSENT_VERSION` so existing opted-in users get a re-consent banner.
+9. **Skills are gitignored except whitelisted.** When working on built-in skills (`skills/skill_creator.py` etc.), `.gitignore` entry `skills/` excludes them by default; whitelist (`!skills/skill_creator.py`) keeps the built-ins tracked. Side effect: `ruff check .` skips skills/ via gitignore — for those files run `ruff check skills/` explicitly.
+10. **Before commit**: `ruff check .`, `python scripts/check_js.py` (if you touched `static/index.html`), `pytest tests/`.


### PR DESCRIPTION
## Summary

Refresh of `CLAUDE.md` to match the v0.18.x state of the codebase. Diff is +58/-8 lines across the existing structure — no new top-level sections, just updated facts and added subsections under existing ones.

## What changed

- **Test count + provider count** — bumped to ~495 tests / 10 providers; added `pytest tests/test_telemetry.py -v` to the example commands.
- **New section: Skill Creator** — documents the 5-step LLM pipeline (plan → tools → mapping → DDL → assemble+smoke), the `skill_<name>_*` table-prefix rule, and the AST-scoped param-usage check.
- **New section: Telemetry** — the privacy contract (5 whitelisted events, closed-enum string props), opt-in flow, raw vs Countly senders, consent versioning, two-gate refusal under stale consent. Points to `docs/PRIVACY.md` for the full inventory.
- **Camera entry** — v0.18.2 fixes: WS event-name unify (`get_frame` / `frame_request`), brightness auto-detect across indices 0–3 with black-frame guard, resolution + JPEG quality settings.
- **Soul rules 14 + 16** — NEW INTEGRATION (`create_skill` + STOP turn), EXTERNAL-WAIT (no blocking shell on OAuth / 2FA flows).
- **Tests section** — added `test_telemetry.py`, `test_text_to_tool_extraction.py`, `test_camera_settings.py`; KeyboardInterrupt flake note for `test_telemetry_wireup.py`.
- **Add-a-feature checklist** — items 8 (telemetry events + consent bump) and 9 (skills gitignore quirk: `ruff check skills/` separately for built-in skill files).
- **Env vars** — postscript noting telemetry settings live in `EDITABLE_SETTINGS`, not env vars.

## Why now

Several v0.17 facts were stale (test count, provider list, no Skill Creator coverage, no Telemetry coverage). Future Claude sessions in this repo were starting from outdated context. Refreshing now means the next `/init` won't have to redo this work.

## Test plan

- [x] `python scripts/check_js.py` — N/A (no `static/index.html` change)
- [x] `python -c "import ast, pathlib; [ast.parse(p.read_text(encoding='utf-8'), filename=str(p), feature_version=(3,11)) for p in pathlib.Path('.').glob('*.py')]"` — N/A (no .py change)
- [x] Skim — claims about telemetry/skill_creator/camera match the actual modules.

🤖 Generated with [Claude Code](https://claude.com/claude-code)