### PR TITLE
fix(telemetry): drop verify-step that false-fires "did not persist" toast

### DIFF
--- a/static/index.html
+++ b/static/index.html
@@ -7553,15 +7553,6 @@ async function checkTelemetryFirstRun() {
             _decided = true;
             try {
               await api('/api/telemetry/opt-out', { method: 'POST' });
-              // Verify persistence — if the server didn't actually
-              // stamp consent_version, the modal would loop on refresh.
-              // We've seen reports of this; fail-loud so the user gets
-              // a clear error instead of a silent loop.
-              const v = await api('/api/telemetry/status');
-              if (!v.consent_decision_made) {
-                toast('opt-out did not persist — check server logs', 'err');
-                return false;  // keep modal open
-              }
               toast('telemetry off');
             } catch { toast('failed to save choice', 'err'); return false; }
         }},
@@ -7569,11 +7560,6 @@ async function checkTelemetryFirstRun() {
             _decided = true;
             try {
               await api('/api/telemetry/opt-in', { method: 'POST' });
-              const v = await api('/api/telemetry/status');
-              if (!v.consent_decision_made) {
-                toast('opt-in did not persist — check server logs', 'err');
-                return false;
-              }
               toast('telemetry enabled — thank you!');
             } catch { toast('failed to enable', 'err'); return false; }
         }},

--- a/tests/test_telemetry.py
+++ b/tests/test_telemetry.py
@@ -971,3 +971,72 @@ def test_default_sender_dispatches_to_raw_by_default(monkeypatch, configured_end
     configured_endpoint.track_event("feature_first_use", {"feature": "camera_capture"})
     configured_endpoint._default_sender(configured_endpoint.get_pending_events())
     assert called == {"raw": True, "countly": False}
+
+
+# ── HTTP endpoint flow (mirrors first-run modal in static/index.html) ─
+
+
+@pytest.fixture
+def http_client(fresh_tel):
+    """TestClient bound to a fresh qwe_temp_data_dir + reloaded telemetry.
+
+    Mirrors what the browser does when the first-run modal opens:
+    GET /status → modal opens iff consent_decision_made:false → user
+    clicks Enable → POST /opt-in → on next load, GET /status must say
+    consent_decision_made:true (otherwise the modal would re-prompt).
+    Pinning this contract here prevents a regression like #unknown
+    where a UI-side verify-step started crying false-positive on a
+    correctly-persisted opt-in.
+    """
+    from fastapi.testclient import TestClient
+    import server
+    with TestClient(server.app) as c:
+        yield c
+
+
+def test_status_endpoint_reports_no_decision_on_fresh_install(http_client):
+    """First-run state: telemetry off, no consent stamped, modal would open."""
+    r = http_client.get("/api/telemetry/status")
+    assert r.status_code == 200
+    j = r.json()
+    assert j["enabled"] is False
+    assert j["consent_decision_made"] is False
+    assert j["consent_needs_reprompt"] is False  # nothing to re-prompt yet
+    assert j["current_consent_version"] >= 1
+
+
+def test_opt_in_then_status_reports_decision_made(http_client):
+    """The contract the modal relies on: after POST /opt-in, the next
+    GET /status must report consent_decision_made:true. If this ever
+    breaks, the first-run modal will loop on every page reload.
+    """
+    # Fresh state — modal would open
+    pre = http_client.get("/api/telemetry/status").json()
+    assert pre["consent_decision_made"] is False
+
+    # User clicks Enable
+    r = http_client.post("/api/telemetry/opt-in")
+    assert r.status_code == 200
+    assert r.json()["ok"] is True
+
+    # Next page load — modal must NOT re-prompt
+    post = http_client.get("/api/telemetry/status").json()
+    assert post["enabled"] is True
+    assert post["consent_decision_made"] is True
+    assert post["consent_needs_reprompt"] is False
+
+
+def test_opt_out_then_status_reports_decision_made(http_client):
+    """Same contract for the No-thanks branch: explicit opt-out must
+    also stamp consent_version so the modal doesn't re-prompt.
+    """
+    pre = http_client.get("/api/telemetry/status").json()
+    assert pre["consent_decision_made"] is False
+
+    r = http_client.post("/api/telemetry/opt-out")
+    assert r.status_code == 200
+    assert r.json()["ok"] is True
+
+    post = http_client.get("/api/telemetry/status").json()
+    assert post["enabled"] is False
+    assert post["consent_decision_made"] is True  # decision = "no", but a decision


### PR DESCRIPTION
## Summary

Reported: clicking **Enable** in the first-run "Help improve qwe-qwe?" modal shows a scary "opt-in did not persist — check server logs" toast even though the backend persisted consent correctly.

The verify-step that produces this toast was added in `9250876` as defense-in-depth for the previous modal-re-appearing bug. But that bug's real root cause (X/ESC dismiss didn't stamp `consent_version`) was already fixed in `e568596` via the `onClose` fallback. With that fix in place, the verify is dead weight that fires false-positives whenever the browser serves a stale `/status` response from HTTP cache between the boot-time call and the post-Enable verify call.

## Diagnosis

`TestClient(app)` repro shows the backend persists `consent_version=1` + `enabled=1` immediately after POST `/api/telemetry/opt-in` — confirmed via:

```
BEFORE opt-in: consent_decision_made=False
opt-in response: {'ok': True, 'anonymous_id_short': '0f4d7b13...'}
AFTER opt-in:  consent_decision_made=True, telemetry_consent_version=1
```

The user sees the false toast, the modal stays open (because the handler `return false`s on the false-positive), they panic. With this PR, POST 2xx → success toast → modal closes. If a genuine persistence regression ever happens, the modal will simply re-prompt on next reload — same recovery path as before the verify-step was added, with no scary false-positive.

## What changed

**`static/index.html` (-14)** — Drop the `await api('/api/telemetry/status')` verify call from both Enable and No-thanks handlers. Trust POST 2xx; if it throws, show "failed" toast (existing behavior).

**`tests/test_telemetry.py` (+69)** — Three new HTTP-flow regression tests via `TestClient(server.app)` pinning the actual backend contract:
- `test_status_endpoint_reports_no_decision_on_fresh_install` — fresh-install state
- `test_opt_in_then_status_reports_decision_made` — Enable branch
- `test_opt_out_then_status_reports_decision_made` — No-thanks branch (explicit "no" is still a decision)

These would catch a real persistence regression directly. The JS verify-step was the wrong layer to enforce that contract — testing it in pytest is correct, and the toast disappears.

## Test plan

- [x] `pytest tests/test_telemetry.py -q` — 61 pass (was 58, +3 new)
- [x] `ruff check .` — clean
- [x] `python scripts/check_js.py` — clean
- [x] Manual: Enable → success toast → modal closes → reload → no re-prompt

🤖 Generated with [Claude Code](https://claude.com/claude-code)