### PR TITLE
feat(telemetry): add thread_created event with source attribution

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -627,7 +627,7 @@ def handle_thread(args: str):
     # /thread new <name>
     if cmd == "new":
         name = parts[1] if len(parts) > 1 else f"Thread {len(threads.list_all()) + 1}"
-        t = threads.create(name)
+        t = threads.create(name, source="cli")
         threads.switch(t["id"])
         console.print(f"  [green]✓ Created & switched to '{name}' ({t['id']})[/]")
         return

--- a/docs/PRIVACY.md
+++ b/docs/PRIVACY.md
@@ -24,7 +24,7 @@ If you opt in (Settings → Privacy → Telemetry, OR by answering "yes" to the 
 
 ### What gets collected
 
-Every event is declared in [`telemetry.py::ALLOWED_EVENTS`](../telemetry.py) — that's the source of truth, and it's a closed whitelist. Code can't send anything outside this list. Right now there are **5 event types**:
+Every event is declared in [`telemetry.py::ALLOWED_EVENTS`](../telemetry.py) — that's the source of truth, and it's a closed whitelist. Code can't send anything outside this list. Right now there are **6 event types**:
 
 #### `session_start`
 
@@ -57,6 +57,14 @@ Fires when an agent turn finishes (LLM stopped, tool calls done, reply rendered)
 | `output_tokens` | `420` | Same. |
 | `context_hits` | `3` | Memory recall effectiveness. |
 | `source` | `"web"` / `"cli"` / `"telegram"` / `"scheduler"` | Which surface the turn came from. |
+
+#### `thread_created`
+
+Fires every time a new chat thread is created. Lets us see how often users start fresh conversations vs continue existing ones, and whether the trigger was a person or a system surface.
+
+| Field | Example | Why |
+|---|---|---|
+| `source` | One of: `web` / `cli` / `telegram` / `scheduler` / `preset` / `other` | Which surface initiated the thread creation. Closed enum. **Never the thread name, id, or any meta** — those could carry user-typed content like `"acme-Q3-launch"` and deanonymize. |
 
 #### `tool_error`
 

--- a/presets.py
+++ b/presets.py
@@ -1146,7 +1146,7 @@ def ensure_preset_workspace(preset_id: str) -> None:
         if preset_thread:
             threads.switch(preset_thread["id"])
         else:
-            t = threads.create(preset_thread_name)
+            t = threads.create(preset_thread_name, source="preset")
             threads.switch(t["id"])
         _log.info(f"thread → '{preset_thread_name}'")
 

--- a/scheduler.py
+++ b/scheduler.py
@@ -121,7 +121,7 @@ def add(name: str, task: str, schedule: str, skip_dry_run: bool = False) -> dict
                 "routine_name": name,
                 "schedule": schedule,
                 "created_at": time.time(),
-            })
+            }, source="scheduler")
             routine_thread_id = t["id"]
         except Exception as e:
             _log.warning(f"failed to create routine thread for '{name}': {e}")
@@ -715,7 +715,7 @@ def _ensure_routine_thread(cron_id: int, routine_name: str, schedule: str) -> st
             "routine_name": routine_name,
             "schedule": schedule,
             "backfilled": True,
-        })
+        }, source="scheduler")
         tid = t["id"]
         db.execute("UPDATE scheduled_tasks SET thread_id=? WHERE id=?",
                    (tid, cron_id))

--- a/server.py
+++ b/server.py
@@ -2550,7 +2550,7 @@ async def list_threads(include_archived: bool = False):
 async def create_thread(data: dict):
     """Create a new thread."""
     name = data.get("name", "New Thread")
-    t = threads.create(name, meta=data.get("meta"))
+    t = threads.create(name, meta=data.get("meta"), source="web")
     # Seed message — branch from existing conversation
     seed = data.get("seed_message")
     if seed:

--- a/telegram_bot.py
+++ b/telegram_bot.py
@@ -445,7 +445,7 @@ def _get_or_create_thread_for_topic(chat_id: int, topic_id: int, topic_name: str
             return tid
     # Create new thread
     name = topic_name or f"TG Topic #{topic_id}"
-    t = threads.create(name, meta={"telegram_chat_id": chat_id, "telegram_topic_id": topic_id})
+    t = threads.create(name, meta={"telegram_chat_id": chat_id, "telegram_topic_id": topic_id}, source="telegram")
     set_thread_for_topic(chat_id, topic_id, t["id"])
     _log.info(f"created thread '{name}' ({t['id']}) for topic {topic_id} in chat {chat_id}")
     return t["id"]
@@ -462,7 +462,7 @@ def _get_or_create_dm_thread(chat_id: int) -> str:
         if t:
             return tid
     # Create new thread for this DM
-    t = threads.create("Telegram DM", meta={"telegram_chat_id": chat_id, "telegram_dm": True})
+    t = threads.create("Telegram DM", meta={"telegram_chat_id": chat_id, "telegram_dm": True}, source="telegram")
     db.kv_set(kv_key, t["id"])
     _log.info(f"created DM thread ({t['id']}) for chat {chat_id}")
     return t["id"]

--- a/telemetry.py
+++ b/telemetry.py
@@ -59,7 +59,8 @@ _log = logging.getLogger("qwe.telemetry")
 # them with the new defaults visible.
 #   v1 = first release with a default project endpoint
 #        (qwelytics.deepfounder.ai Countly)
-_CURRENT_CONSENT_VERSION = 1
+#   v2 = added `thread_created` event + extended SOURCES with "preset"
+_CURRENT_CONSENT_VERSION = 2
 
 # ── HTTP send tunables ───────────────────────────────────────────────
 # Single timeout cap for the whole urlopen call. urllib doesn't separate
@@ -155,6 +156,15 @@ ALLOWED_EVENTS: dict[str, dict[str, type]] = {
         # preset_activate / knowledge_index_url / knowledge_index_file
         "feature": str,
     },
+    "thread_created": {
+        # Fires every time a new chat thread is created. Lets us see how
+        # often users start fresh conversations vs continue existing ones,
+        # and whether the trigger was the user (web/cli/telegram) or the
+        # system (scheduler/preset). Source is the only field — no thread
+        # name, no id, nothing that could carry user-typed content.
+        # Allowed values: web / cli / telegram / scheduler / preset / other
+        "source": str,
+    },
 }
 
 # Categories used for tool_categories_used and tool_error.tool_category.
@@ -170,8 +180,11 @@ ERROR_KINDS = frozenset({
     "aborted", "blocked", "not_found", "unauthorized", "other",
 })
 
-# Sources for turn_complete.source.
-SOURCES = frozenset({"web", "cli", "telegram", "scheduler", "other"})
+# Sources for turn_complete.source and thread_created.source.
+# `preset` is only meaningful for thread_created (preset activation
+# creates a thread); turn_complete won't emit it but keeping one
+# enum keeps the validator simple.
+SOURCES = frozenset({"web", "cli", "telegram", "scheduler", "preset", "other"})
 
 # Provider kinds.
 PROVIDER_KINDS = frozenset({
@@ -205,6 +218,7 @@ _ENUM_CONSTRAINTS: dict[tuple[str, str], frozenset] = {
     ("tool_error", "error_kind"): ERROR_KINDS,
     ("skill_creator_pipeline", "outcome"): PIPELINE_OUTCOMES,
     ("feature_first_use", "feature"): FEATURES,
+    ("thread_created", "source"): SOURCES,
 }
 
 # ── Module state ─────────────────────────────────────────────────────

--- a/tests/test_telemetry.py
+++ b/tests/test_telemetry.py
@@ -1040,3 +1040,124 @@ def test_opt_out_then_status_reports_decision_made(http_client):
     post = http_client.get("/api/telemetry/status").json()
     assert post["enabled"] is False
     assert post["consent_decision_made"] is True  # decision = "no", but a decision
+
+
+# ── thread_created event ─────────────────────────────────────────────
+
+
+def test_thread_created_event_in_whitelist(fresh_tel):
+    """The event is part of the validator's closed list — adding new
+    events without ALLOWED_EVENTS update is rejected, so confirming
+    membership is the contract this test pins."""
+    assert "thread_created" in fresh_tel.ALLOWED_EVENTS
+    schema = fresh_tel.ALLOWED_EVENTS["thread_created"]
+    # The event carries ONLY a source — no name, no id, no meta. If
+    # someone adds free-text fields here, this test fails loud.
+    assert schema == {"source": str}
+
+
+def test_thread_created_accepts_each_known_source(fresh_tel):
+    """Every source value the call sites use (web/cli/telegram/
+    scheduler/preset) must be accepted by the validator. Catches a
+    typo regression where one site sends e.g. "tg" or "schedule"."""
+    fresh_tel.opt_in()
+    for src in ("web", "cli", "telegram", "scheduler", "preset", "other"):
+        fresh_tel.clear_queue()
+        accepted = fresh_tel.track_event("thread_created", {"source": src})
+        assert accepted is True, f"source={src!r} rejected"
+        assert fresh_tel.queue_size() == 1
+        evt = fresh_tel.get_pending_events()[0]
+        assert evt["event"] == "thread_created"
+        assert evt["props"] == {"source": src}
+
+
+def test_thread_created_rejects_unknown_source(fresh_tel):
+    """Free-text source must be dropped — closed enum is the privacy
+    guarantee that prevents thread names from leaking via this field."""
+    fresh_tel.opt_in()
+    accepted = fresh_tel.track_event("thread_created", {"source": "my_custom_thing"})
+    assert accepted is False
+    assert fresh_tel.queue_size() == 0
+
+
+def test_thread_created_rejects_extra_keys(fresh_tel):
+    """The thread name + meta are NEVER part of the event. If a future
+    refactor tries to attach them, the validator drops the event."""
+    fresh_tel.opt_in()
+    accepted = fresh_tel.track_event("thread_created", {
+        "source": "web",
+        "name": "secret-project-x",  # smuggling attempt
+    })
+    assert accepted is False
+    assert fresh_tel.queue_size() == 0
+
+
+def test_threads_create_emits_telemetry_when_enabled(qwe_temp_data_dir, monkeypatch):
+    """End-to-end: threads.create(source=...) routes through the
+    telemetry helper and lands in the queue with the right shape."""
+    import importlib
+    import sys
+    if "telemetry" in sys.modules:
+        importlib.reload(sys.modules["telemetry"])
+    if "threads" in sys.modules:
+        importlib.reload(sys.modules["threads"])
+    import telemetry as t
+    import threads
+    t.opt_in()
+    t.clear_queue()
+
+    threads.create("hello", source="web")
+
+    assert t.queue_size() == 1
+    evt = t.get_pending_events()[0]
+    assert evt["event"] == "thread_created"
+    assert evt["props"] == {"source": "web"}
+
+
+def test_threads_create_emits_nothing_when_disabled(qwe_temp_data_dir, monkeypatch):
+    """Default OFF — threads.create() must NOT touch the queue when
+    telemetry is disabled. Privacy contract."""
+    import importlib
+    import sys
+    if "telemetry" in sys.modules:
+        importlib.reload(sys.modules["telemetry"])
+    if "threads" in sys.modules:
+        importlib.reload(sys.modules["threads"])
+    import telemetry as t
+    import threads
+    assert t.enabled() is False  # default
+    t.clear_queue()
+
+    threads.create("hello")  # no source kwarg → defaults to "other"
+
+    assert t.queue_size() == 0
+
+
+def test_threads_create_coerces_unknown_source_to_other(qwe_temp_data_dir, monkeypatch):
+    """The helper coerces invalid sources to 'other' so a caller who
+    passes a typo doesn't drop the event entirely (still useful as a
+    count, just bucketed)."""
+    import importlib
+    import sys
+    if "telemetry" in sys.modules:
+        importlib.reload(sys.modules["telemetry"])
+    if "threads" in sys.modules:
+        importlib.reload(sys.modules["threads"])
+    import telemetry as t
+    import threads
+    t.opt_in()
+    t.clear_queue()
+
+    threads.create("hello", source="tgbot")  # not in SOURCES
+
+    assert t.queue_size() == 1
+    evt = t.get_pending_events()[0]
+    assert evt["props"] == {"source": "other"}
+
+
+def test_consent_version_bumped_to_2(fresh_tel):
+    """thread_created adoption bumped consent from v1 to v2. Pinning
+    so a future refactor that lowers it (or forgets to bump again)
+    is caught here — without this, opted-in users would never see
+    the re-confirm banner for the new event type."""
+    assert fresh_tel._CURRENT_CONSENT_VERSION >= 2

--- a/threads.py
+++ b/threads.py
@@ -67,8 +67,15 @@ def _gen_id() -> str:
 
 # ── CRUD ──
 
-def create(name: str, meta: dict | None = None) -> dict:
-    """Create a new thread. Returns thread dict."""
+def create(name: str, meta: dict | None = None, source: str = "other") -> dict:
+    """Create a new thread. Returns thread dict.
+
+    `source` identifies which surface initiated the creation, for the
+    opt-in `thread_created` telemetry event. Closed-enum values:
+    web / cli / telegram / scheduler / preset / other. Anything else
+    coerces to "other" inside the telemetry helper. The thread name +
+    meta are NEVER part of the event — only the source.
+    """
     _ensure_table()
     tid = _gen_id()
     now = time.time()
@@ -76,8 +83,24 @@ def create(name: str, meta: dict | None = None) -> dict:
         "INSERT INTO threads (id, name, created_at, updated_at, meta) VALUES (?,?,?,?,?)",
         (tid, name, now, now, json.dumps(meta or {}))
     )
-    _log.info(f"thread created: {tid} '{name}'")
+    _log.info(f"thread created: {tid} '{name}' [source={source}]")
+    _emit_thread_created_telemetry(source)
     return {"id": tid, "name": name, "created_at": now, "updated_at": now, "archived": False, "messages": 0}
+
+
+def _emit_thread_created_telemetry(source: str) -> None:
+    """Lazy-imported telemetry emit. No-op when telemetry is disabled
+    or anything goes wrong — this must NEVER raise into the caller's
+    happy path."""
+    try:
+        import telemetry
+        if not telemetry.enabled():
+            return
+        safe = source if source in telemetry.SOURCES else "other"
+        telemetry.track_event("thread_created", {"source": safe})
+    except Exception:
+        # Belt and suspenders — telemetry must never break thread creation
+        _log.debug("thread_created telemetry emit failed", exc_info=True)
 
 
 def get(tid: str) -> dict | None:


### PR DESCRIPTION
## Why

User asked for visibility into how often new chats are created — currently the project has no signal for this. Adds a 6th opt-in telemetry event firing once per thread creation, attributed by surface so we can tell apart user-driven (web/cli/telegram) from system-driven (scheduler/preset) volume.

## Schema

Single closed-enum field. The thread name + meta are **never** part of the event — those can carry project names, internal jargon, or user-typed text. `test_thread_created_rejects_extra_keys` pins this.

```python
"thread_created": {"source": str}  # web/cli/telegram/scheduler/preset/other
```

## Wiring

`threads.create()` gains an optional `source` kwarg (default `"other"`). A lazy-imported helper emits the event when telemetry is enabled and swallows any exception so a telemetry hiccup never breaks thread creation.

| Call site | Source value |
|---|---|
| `cli.py` (`/thread new`) | `cli` |
| `server.py` (`POST /api/threads`) | `web` |
| `telegram_bot.py` (topic + DM) | `telegram` |
| `scheduler.py` (create + backfill) | `scheduler` |
| `presets.py` (preset activation) | `preset` |

## Consent versioning

`_CURRENT_CONSENT_VERSION` bumped 1 → 2 because `ALLOWED_EVENTS` shape changed. Existing opt-in users will see the "policy updated, please re-confirm" yellow banner in Settings → Privacy until they re-stamp. The stale-consent gate in `track_event()` and `flush()` already enforces the no-send-under-stale-consent rule, so no events leak under the old policy.

## Tests

8 new tests in `tests/test_telemetry.py` pinning the privacy contract:

- `thread_created` in `ALLOWED_EVENTS`, schema is exactly `{source: str}`
- Every known source value (web/cli/telegram/scheduler/preset/other) accepted
- Unknown source rejected (closed-enum guarantee)
- Extra keys (e.g. smuggled thread name) rejected
- `threads.create()` emits when enabled
- `threads.create()` emits NOTHING when disabled (default OFF — privacy contract)
- `threads.create()` coerces unknown source to `"other"` instead of dropping the event
- `_CURRENT_CONSENT_VERSION >= 2` pin

## Test plan

- [x] `pytest tests/test_telemetry.py -q` — 69 pass (was 61, +8 new)
- [x] `pytest tests/ -q` — 508 pass, 3 skip, 0 fail
- [x] `ruff check .` — clean
- [x] No edits needed in `tests/test_thread_folders.py` or `tests/test_integration.py` since the `source` kwarg has a default → existing call sites still type-check.

## Deploy notes

After merge: bump `VERSION` to `0.18.5` and ship a release. Existing opted-in users will see the re-confirm banner; first-time users will see the standard first-run modal as before.

🤖 Generated with [Claude Code](https://claude.com/claude-code)