### PR TITLE
feat(presets): "From the blog" RSS strip

### DIFF
--- a/docs/PRIVACY.md
+++ b/docs/PRIVACY.md
@@ -117,6 +117,12 @@ Every event is wrapped with:
 
 The whitelist in `telemetry.py::ALLOWED_EVENTS` is **type-strict** — every prop has a declared Python type, and string-valued props that could carry free text instead use a closed enum (e.g. `provider_kind`, `tool_category`, `error_kind`). A future refactor that accidentally added a string field couldn't sneak chat content past the validator without explicitly editing the whitelist.
 
+### Other project-controlled outbound HTTP (NOT telemetry)
+
+These are not subject to the opt-in toggle because no user data is sent — but for full transparency:
+
+- **Blog feed** — when you open the Presets view, the qwe-qwe server fetches `https://deepfounder.ai/tag/qwe-qwe/rss/` to render the "From the blog" strip with project announcements. Cached server-side for 30 minutes, request body is empty, no `anonymous_id` or telemetry data is attached. The only signal `deepfounder.ai` receives is "an install asked for the feed" (your IP + a `qwe-qwe/<version>` User-Agent). Disable by simply not visiting Presets; we may add an explicit toggle if users ask.
+
 ### Where the data goes
 
 Telemetry is **off by default** — you must explicitly opt in via the first-run prompt or Settings → Privacy → Telemetry.

--- a/server.py
+++ b/server.py
@@ -2051,6 +2051,102 @@ async def file_browse(request: Request):
     }
 
 
+# ── Project blog feed (shown in the Presets view) ───────────────────────
+#
+# Fetches https://deepfounder.ai/tag/qwe-qwe/rss/ server-side, parses it,
+# returns a small JSON list. Server-side fetch keeps:
+#   - the user's IP off deepfounder.ai (only the install reaches out, and
+#     we cache for 30 min so the request rate is bounded);
+#   - the wire format normalized — UI renders a tiny shape, not raw XML;
+#   - graceful degradation — if deepfounder.ai is down, we return the
+#     last cached items + an `error` field, never break the Presets view.
+#
+# Privacy: this is a project-controlled outbound HTTP, not telemetry.
+# It carries no body, no anonymous_id — the only signal deepfounder.ai
+# sees is "an install asked for the feed". Documented in PRIVACY.md.
+
+_FEED_URL = "https://deepfounder.ai/tag/qwe-qwe/rss/"
+_FEED_CACHE_TTL_S = 1800  # 30 min — feed `<ttl>` says 60 (minutes) so we're well under
+_FEED_TIMEOUT_S = 15.0
+_FEED_MAX_ITEMS = 10
+_feed_cache_lock = threading.Lock()
+_feed_cache: dict = {"items": [], "fetched_at": 0.0, "etag": ""}
+
+
+def _parse_blog_feed_xml(xml_bytes: bytes) -> list[dict]:
+    """Parse an RSS 2.0 feed into a small JSON list.
+
+    Bounds every string so a malicious/malformed feed can't blow up the
+    response. Skips items missing title or link. Returns at most
+    `_FEED_MAX_ITEMS` newest entries (RSS feeds list newest first).
+    """
+    import xml.etree.ElementTree as ET
+    root = ET.fromstring(xml_bytes)
+    out: list[dict] = []
+    # `iter("item")` walks the tree depth-first — works whether items are
+    # at /rss/channel/item or wrapped differently in some Ghost variants.
+    for item in root.iter("item"):
+        title = (item.findtext("title") or "").strip()
+        link = (item.findtext("link") or "").strip()
+        if not title or not link:
+            continue
+        description = (item.findtext("description") or "").strip()
+        pub_date = (item.findtext("pubDate") or "").strip()
+        guid = (item.findtext("guid") or "").strip()
+        cats = []
+        for c in item.findall("category"):
+            txt = (c.text or "").strip()
+            if txt:
+                cats.append(txt[:50])
+            if len(cats) >= 8:
+                break
+        out.append({
+            "title": title[:300],
+            "link": link[:500],
+            "description": description[:500],
+            "pub_date": pub_date[:64],
+            "guid": guid[:128],
+            "categories": cats,
+        })
+        if len(out) >= _FEED_MAX_ITEMS:
+            break
+    return out
+
+
+@app.get("/api/feed/blog")
+async def blog_feed():
+    """Project blog feed (RSS) for the Presets view.
+
+    Cached in-process for 30 minutes. On fetch failure, returns the last
+    successful payload (if any) plus a non-fatal `error` field so the UI
+    can render gracefully. Always returns 200; never raises into the UI.
+    """
+    now = time.time()
+    with _feed_cache_lock:
+        if _feed_cache["items"] and (now - _feed_cache["fetched_at"]) < _FEED_CACHE_TTL_S:
+            return {"items": _feed_cache["items"], "cached": True,
+                    "fetched_at": _feed_cache["fetched_at"]}
+    try:
+        ua = f"qwe-qwe/{config.VERSION}"
+        req = urllib.request.Request(_FEED_URL, headers={"User-Agent": ua})
+        with urllib.request.urlopen(req, timeout=_FEED_TIMEOUT_S) as r:
+            body = r.read()
+        items = _parse_blog_feed_xml(body)
+        with _feed_cache_lock:
+            _feed_cache["items"] = items
+            _feed_cache["fetched_at"] = now
+        return {"items": items, "cached": False, "fetched_at": now}
+    except Exception as e:
+        # Never break the UI — fall back to whatever we cached previously,
+        # or an empty list on cold cache. Log loudly so operators notice.
+        _log.warning("blog feed fetch failed: %s", e)
+        with _feed_cache_lock:
+            stale = list(_feed_cache["items"])
+            stale_ts = _feed_cache["fetched_at"]
+        return {"items": stale, "cached": False, "fetched_at": stale_ts,
+                "error": str(e)[:200]}
+
+
 # ── Business presets ────────────────────────────────────────────────────
 
 @app.get("/api/presets")

--- a/static/index.html
+++ b/static/index.html
@@ -954,6 +954,51 @@ details.tool[open] > summary .tool-result { color: var(--fg-4); }
   display: flex; flex-direction: column; align-items: center; justify-content: center;
   min-height: 180px; color: var(--fg-3); cursor: pointer;
 }
+
+/* "From the blog" feed strip — rendered above the preset grid.
+   Compact list of post titles + dates linking to deepfounder.ai. */
+.feed-strip {
+  margin-bottom: 22px; padding: 14px 16px;
+  background: var(--bg-inspector); border: 1px solid var(--line);
+  border-radius: 10px;
+}
+.feed-strip .feed-hdr {
+  display: flex; align-items: center; justify-content: space-between;
+  margin-bottom: 10px;
+}
+.feed-strip .feed-hdr .feed-title {
+  font-size: 11px; letter-spacing: 0.06em; text-transform: uppercase;
+  color: var(--fg-3); font-weight: 500;
+}
+.feed-strip .feed-hdr .feed-more {
+  font-size: 11.5px; color: var(--fg-3); text-decoration: none;
+  display: inline-flex; align-items: center; gap: 4px;
+}
+.feed-strip .feed-hdr .feed-more:hover { color: var(--fg-2); }
+.feed-strip .feed-list { display: flex; flex-direction: column; gap: 0; }
+.feed-strip .feed-item {
+  display: block; padding: 10px 0; text-decoration: none; color: inherit;
+  border-top: 1px solid var(--line);
+}
+.feed-strip .feed-item:first-child { border-top: 0; padding-top: 4px; }
+.feed-strip .feed-item:hover .it-title { color: var(--accent); }
+.feed-strip .feed-item .it-row {
+  display: flex; align-items: baseline; gap: 10px; margin-bottom: 4px;
+}
+.feed-strip .feed-item .it-title {
+  font-size: 13px; font-weight: 500; color: var(--fg);
+  line-height: 1.4; flex: 1; transition: color 0.12s;
+}
+.feed-strip .feed-item .it-date {
+  font-family: var(--font-mono); font-size: 10.5px; color: var(--fg-4);
+  font-variant-numeric: tabular-nums; flex-shrink: 0;
+}
+.feed-strip .feed-item .it-desc {
+  font-size: 11.5px; color: var(--fg-3); line-height: 1.55;
+  display: -webkit-box; -webkit-line-clamp: 2; -webkit-box-orient: vertical;
+  overflow: hidden;
+}
+.feed-strip.empty { display: none; }
 .blank-preset .circle {
   width: 40px; height: 40px; border-radius: 50%;
   background: var(--surface); border: 1px solid var(--line-2);
@@ -1755,6 +1800,8 @@ const state = {
   memoryEntries: [],
   cronJobs: [],
   presetList: [],
+  blogFeed: [],          // RSS items from deepfounder.ai/tag/qwe-qwe — lazy-loaded when Presets view opens
+  blogFeedLoaded: false, // gate so we only fetch once per session even on rapid view switches
   kbFiles: [],
   memoryEntries: [],   // plain memories (Save-to-memory button + agent's memory_save calls)
   kbGraph: { nodes: [], links: [] },
@@ -3385,6 +3432,20 @@ async function loadPresets() {
   } catch { state.presetList = []; render(); }
 }
 
+async function loadBlogFeed() {
+  // Fire-and-forget on Presets view entry. Backend caches for 30 min so
+  // hopping in/out of the view doesn't repeatedly hit deepfounder.ai.
+  // Failures are swallowed — the Presets view stays usable without the
+  // banner.
+  if (state.blogFeedLoaded) return;
+  state.blogFeedLoaded = true;
+  try {
+    const r = await api('/api/feed/blog');
+    state.blogFeed = (r && r.items) || [];
+  } catch { state.blogFeed = []; }
+  render();
+}
+
 function render() {
   const root = document.getElementById('app');
   // Preserve scroll position of the chat scroller across re-renders.
@@ -4571,6 +4632,7 @@ function renderPresetsView() {
       '<h1>Agent presets</h1>' +
       '<p class="sub">Pre-configured agents with curated tools, prompts, and memory scopes. Each preset has its own isolated workspace.</p>' +
     '</div><button class="page-primary" data-act="preset-install">' + ico('plusSmall', 12) + ' Install</button></div>' +
+    renderBlogFeedStrip() +
     '<div class="card-grid">' +
       presets.map((p, i) => {
         const c = colors[i % colors.length], pico = icons[i % icons.length];
@@ -4600,6 +4662,49 @@ function renderPresetsView() {
         '<div class="mono" style="font-size:10.5px;color:var(--fg-4);margin-top:4px">start from scratch</div>' +
       '</div>' +
     '</div></div></div>';
+}
+
+function renderBlogFeedStrip() {
+  // Renders nothing while the feed is still loading or returned empty,
+  // rather than reserving an empty box that visually competes with the
+  // page header.
+  const items = (state.blogFeed || []).slice(0, 5);
+  if (!items.length) return '';
+  const itemsHtml = items.map(it => {
+    const url = it.link || '#';
+    const date = formatFeedDate(it.pub_date);
+    return '<a class="feed-item" href="' + esc(url) + '" target="_blank" rel="noopener noreferrer">' +
+      '<div class="it-row">' +
+        '<div class="it-title">' + esc(it.title || '(untitled)') + '</div>' +
+        (date ? '<div class="it-date">' + esc(date) + '</div>' : '') +
+      '</div>' +
+      (it.description ? '<div class="it-desc">' + esc(it.description) + '</div>' : '') +
+    '</a>';
+  }).join('');
+  return '<div class="feed-strip">' +
+    '<div class="feed-hdr">' +
+      '<span class="feed-title">From the blog</span>' +
+      '<a class="feed-more" href="https://deepfounder.ai/tag/qwe-qwe/" target="_blank" rel="noopener noreferrer">all posts →</a>' +
+    '</div>' +
+    '<div class="feed-list">' + itemsHtml + '</div>' +
+  '</div>';
+}
+
+function formatFeedDate(rfc822) {
+  // RSS uses RFC 822 (e.g. "Fri, 08 May 2026 12:13:18 GMT"). Browsers'
+  // Date parser handles it. Fall back to the raw string on failure so
+  // we never lose the date entirely.
+  if (!rfc822) return '';
+  try {
+    const d = new Date(rfc822);
+    if (isNaN(d.getTime())) return rfc822;
+    const now = new Date();
+    const days = Math.floor((now - d) / 86400000);
+    if (days < 1) return 'today';
+    if (days < 2) return 'yesterday';
+    if (days < 30) return days + 'd ago';
+    return d.toLocaleDateString(undefined, { month: 'short', day: 'numeric', year: d.getFullYear() === now.getFullYear() ? undefined : 'numeric' });
+  } catch { return rfc822; }
 }
 
 function settingRow(key, desc, controlHtml) {
@@ -6052,7 +6157,7 @@ function go(view) {
   render();
   if (view === 'memory') loadMemory();
   if (view === 'scheduler') loadCron();
-  if (view === 'presets') loadPresets();
+  if (view === 'presets') { loadPresets(); loadBlogFeed(); }
   if (view === 'settings') openSettingsTab(state.settingsTab);
 }
 

--- a/tests/test_blog_feed.py
+++ b/tests/test_blog_feed.py
@@ -1,0 +1,244 @@
+"""Tests for the project blog feed endpoint (Presets view).
+
+The endpoint is a small server-side proxy over `https://deepfounder.ai/
+tag/qwe-qwe/rss/`. We cache for 30 minutes and degrade gracefully when
+the upstream is unreachable. Tests pin:
+
+- the parser's bounds (string length, item count) so a malicious /
+  malformed feed can't blow up the response
+- the parser's tolerance of incomplete items (skips, doesn't raise)
+- the cache TTL (warm hits don't re-fetch)
+- graceful fallback to last-known items on fetch failure
+- always returns 200 — never raises into the UI
+"""
+
+from __future__ import annotations
+
+import io
+import time
+
+import pytest
+
+
+def _make_feed(items_xml: str = "") -> bytes:
+    """Wrap a list of <item>…</item> blocks into a minimal RSS 2.0 feed."""
+    return (
+        '<?xml version="1.0" encoding="UTF-8"?>'
+        '<rss version="2.0">'
+        '<channel>'
+        '<title>qwe-qwe</title>'
+        '<link>https://deepfounder.ai/</link>'
+        '<description>test</description>'
+        f'{items_xml}'
+        '</channel>'
+        '</rss>'
+    ).encode("utf-8")
+
+
+def _item(title="t", link="https://example.com/a", description="d",
+          pub_date="Fri, 08 May 2026 12:13:18 GMT", categories=None):
+    cats = "".join(f"<category><![CDATA[{c}]]></category>" for c in (categories or []))
+    return (
+        "<item>"
+        f"<title><![CDATA[{title}]]></title>"
+        f"<link>{link}</link>"
+        f"<description><![CDATA[{description}]]></description>"
+        f"<pubDate>{pub_date}</pubDate>"
+        f"<guid>{link}</guid>"
+        f"{cats}"
+        "</item>"
+    )
+
+
+@pytest.fixture
+def fresh_server(qwe_temp_data_dir, monkeypatch):
+    """Reload server so we get a fresh `_feed_cache` per test."""
+    import importlib
+    import sys
+    if "server" in sys.modules:
+        importlib.reload(sys.modules["server"])
+    import server
+    return server
+
+
+# ── Parser unit tests ───────────────────────────────────────────────
+
+
+def test_parse_returns_empty_list_for_empty_feed(fresh_server):
+    assert fresh_server._parse_blog_feed_xml(_make_feed("")) == []
+
+
+def test_parse_extracts_known_fields(fresh_server):
+    body = _make_feed(_item(
+        title="Hello World",
+        link="https://deepfounder.ai/post-1/",
+        description="A short summary",
+        pub_date="Fri, 08 May 2026 12:00:00 GMT",
+        categories=["qwe-qwe", "release"],
+    ))
+    items = fresh_server._parse_blog_feed_xml(body)
+    assert len(items) == 1
+    it = items[0]
+    assert it["title"] == "Hello World"
+    assert it["link"] == "https://deepfounder.ai/post-1/"
+    assert it["description"] == "A short summary"
+    assert it["pub_date"] == "Fri, 08 May 2026 12:00:00 GMT"
+    assert it["categories"] == ["qwe-qwe", "release"]
+    # guid populated from <guid>; we set it to the link in _item()
+    assert it["guid"] == "https://deepfounder.ai/post-1/"
+
+
+def test_parse_skips_items_missing_title_or_link(fresh_server):
+    """Items without both title and link are useless to the UI — skip
+    rather than render a broken card."""
+    body = _make_feed(
+        "<item><title>only-title</title></item>"
+        "<item><link>https://example.com/only-link</link></item>"
+        + _item(title="real", link="https://example.com/real")
+    )
+    items = fresh_server._parse_blog_feed_xml(body)
+    assert len(items) == 1
+    assert items[0]["title"] == "real"
+
+
+def test_parse_caps_at_max_items(fresh_server):
+    """No matter how many items the upstream lists, we only return
+    `_FEED_MAX_ITEMS`. Bounded payload → bounded UI render cost."""
+    cap = fresh_server._FEED_MAX_ITEMS
+    items_xml = "".join(_item(title=f"t{i}", link=f"https://example.com/{i}")
+                        for i in range(cap + 5))
+    items = fresh_server._parse_blog_feed_xml(_make_feed(items_xml))
+    assert len(items) == cap
+
+
+def test_parse_truncates_oversize_strings(fresh_server):
+    """A pathological / malicious feed shouldn't be able to push a
+    50KB title through to the JSON response. Each field is bounded."""
+    long_title = "X" * 5000
+    long_desc = "Y" * 5000
+    body = _make_feed(_item(
+        title=long_title, description=long_desc,
+        link="https://example.com/x",
+    ))
+    items = fresh_server._parse_blog_feed_xml(body)
+    assert len(items) == 1
+    assert len(items[0]["title"]) <= 300
+    assert len(items[0]["description"]) <= 500
+
+
+def test_parse_caps_categories_count(fresh_server):
+    """≤8 categories per item, regardless of upstream."""
+    body = _make_feed(_item(categories=[f"cat{i}" for i in range(20)]))
+    items = fresh_server._parse_blog_feed_xml(body)
+    assert len(items[0]["categories"]) <= 8
+
+
+def test_parse_raises_on_malformed_xml(fresh_server):
+    """The parser surfaces XML errors — the endpoint catches them and
+    returns a graceful fallback. We pin the boundary here: parser =
+    strict, endpoint = forgiving."""
+    import xml.etree.ElementTree as ET
+    with pytest.raises(ET.ParseError):
+        fresh_server._parse_blog_feed_xml(b"this is not xml at all <<>")
+
+
+# ── Endpoint behavior ──────────────────────────────────────────────
+
+
+@pytest.fixture
+def http_client(fresh_server):
+    """TestClient bound to the freshly-loaded server."""
+    from fastapi.testclient import TestClient
+    with TestClient(fresh_server.app) as c:
+        yield c
+
+
+@pytest.fixture
+def mock_urlopen(monkeypatch, fresh_server):
+    """Replace urllib.request.urlopen so tests don't hit the live feed.
+
+    Yields a controller object: assign `.body` (bytes) to set the next
+    response, or `.exc` to make the next call raise.
+    """
+    class _Resp:
+        def __init__(self, body):
+            self._body = body
+        def read(self):
+            return self._body
+        def __enter__(self):
+            return self
+        def __exit__(self, *a):
+            return False
+
+    class _Controller:
+        def __init__(self):
+            self.body = _make_feed(_item())
+            self.exc = None
+            self.calls = 0
+
+        def urlopen(self, req, timeout=None):
+            self.calls += 1
+            if self.exc is not None:
+                raise self.exc
+            return _Resp(self.body)
+
+    ctrl = _Controller()
+    import server as srv  # the freshly-loaded one
+    monkeypatch.setattr(srv.urllib.request, "urlopen", ctrl.urlopen)
+    return ctrl
+
+
+def test_endpoint_returns_items_on_first_call(http_client, mock_urlopen):
+    r = http_client.get("/api/feed/blog")
+    assert r.status_code == 200
+    j = r.json()
+    assert j["cached"] is False
+    assert len(j["items"]) == 1
+    assert j["items"][0]["title"] == "t"
+    assert mock_urlopen.calls == 1
+
+
+def test_endpoint_serves_warm_cache(http_client, mock_urlopen):
+    """Second call within the TTL should NOT touch the network."""
+    http_client.get("/api/feed/blog")
+    r = http_client.get("/api/feed/blog")
+    j = r.json()
+    assert j["cached"] is True
+    assert mock_urlopen.calls == 1  # still 1
+
+
+def test_endpoint_falls_back_to_stale_on_error(http_client, mock_urlopen, fresh_server):
+    """If a fresh fetch is needed but upstream is down, return the
+    last-known items + an `error` field. Never break the Presets view."""
+    # Prime the cache with one good fetch
+    http_client.get("/api/feed/blog")
+    # Force the cache to be stale so the next call attempts a refetch
+    fresh_server._feed_cache["fetched_at"] = 0.0
+    # Now break the network
+    mock_urlopen.exc = OSError("network down")
+    r = http_client.get("/api/feed/blog")
+    assert r.status_code == 200  # still 200 — never raise into UI
+    j = r.json()
+    assert "error" in j
+    assert "network down" in j["error"]
+    # And we still serve the cached items
+    assert len(j["items"]) == 1
+
+
+def test_endpoint_returns_empty_items_on_cold_failure(http_client, mock_urlopen):
+    """Worst case: cold cache + upstream down. Return `items: []` +
+    `error`, NOT 500. The UI renders nothing in this case (empty
+    feed → strip hidden) but the rest of the Presets view works."""
+    mock_urlopen.exc = OSError("dns failed")
+    r = http_client.get("/api/feed/blog")
+    assert r.status_code == 200
+    j = r.json()
+    assert j["items"] == []
+    assert "error" in j
+
+
+def test_endpoint_url_points_at_project_blog(fresh_server):
+    """Pin the feed URL so a refactor that drops the trailing /rss/
+    doesn't silently make us hit a 404 page (which Ghost serves with
+    200 + HTML body — would break the parser)."""
+    assert fresh_server._FEED_URL == "https://deepfounder.ai/tag/qwe-qwe/rss/"


### PR DESCRIPTION
## Why

User asked for an RSS feed in the Presets section pointing at https://deepfounder.ai/tag/qwe-qwe/rss/, so users see project announcements (and new presets) without leaving the app.

## What changed

### Backend — `server.py` (+96)

- `GET /api/feed/blog` — server-side proxy of the project blog RSS feed. 30-minute in-process cache, 15-second upstream timeout, parser bounded on every field (title ≤300, desc ≤500, ≤8 categories, ≤10 items).
- Forgiving on errors: on any `urlopen` failure returns 200 with last-known cached items + an `error` field. Never raises into the UI. Cold-cache + upstream-down → empty list + error, Presets view still works.

### Frontend — `static/index.html` (+107)

- New `state.blogFeed` + one-shot `state.blogFeedLoaded` flag.
- `loadBlogFeed()` fires alongside `loadPresets()` on Presets view entry.
- `renderBlogFeedStrip()` renders up to 5 newest items as a compact list (title + relative date "today / 3d ago / Mar 12" + 2-line description). Empty → nothing rendered, no empty box.
- Each item opens in a new tab with `rel="noopener noreferrer"`.
- New `.feed-strip` CSS, matches existing card aesthetic.

### Privacy — `docs/PRIVACY.md` (+6)

This is project-controlled outbound HTTP, **not telemetry**. No user data, no `anonymous_id`, empty body. The only signal deepfounder.ai receives is "an install asked for the feed" (IP + `qwe-qwe/<ver>` UA). Documented in a new "Other project-controlled outbound HTTP" section so users can audit.

### Tests — `tests/test_blog_feed.py` (+12 tests)

| Test | Pins |
|---|---|
| `test_parse_returns_empty_list_for_empty_feed` | parser handles empty channel |
| `test_parse_extracts_known_fields` | title/link/desc/pubDate/categories shape |
| `test_parse_skips_items_missing_title_or_link` | broken-item tolerance |
| `test_parse_caps_at_max_items` | bounded count |
| `test_parse_truncates_oversize_strings` | bounded sizes (5KB title → 300) |
| `test_parse_caps_categories_count` | ≤8 cats per item |
| `test_parse_raises_on_malformed_xml` | parser strict, endpoint forgiving — boundary pinned |
| `test_endpoint_returns_items_on_first_call` | cold path |
| `test_endpoint_serves_warm_cache` | TTL behavior, no re-fetch |
| `test_endpoint_falls_back_to_stale_on_error` | network-down resilience |
| `test_endpoint_returns_empty_items_on_cold_failure` | worst case → 200, not 500 |
| `test_endpoint_url_points_at_project_blog` | URL regression guard |

`urllib.request.urlopen` is mocked — tests never hit the live feed, CI stays deterministic.

## Test plan

- [x] `pytest tests/test_blog_feed.py -q` — 12 pass
- [x] `pytest tests/ -q` — 520 pass, 3 skip, 0 fail (was 508)
- [x] `ruff check .` — clean
- [x] `python scripts/check_js.py` — clean
- [x] Manual: TestClient hit on `/api/feed/blog` returned 10 items from the live feed, second call `cached:true`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)