### PR TITLE
fix(api): bypass HTTP cache in api() helper — kills modal-loop bug

### DIFF
--- a/static/index.html
+++ b/static/index.html
@@ -1634,6 +1634,15 @@ const api = async (path, opts) => {
   const hasJsonBody = opts.body && typeof opts.body === 'object' && !(opts.body instanceof FormData);
   opts.headers = Object.assign({}, opts.headers, hasJsonBody ? { 'Content-Type': 'application/json' } : {});
   if (hasJsonBody) opts.body = JSON.stringify(opts.body);
+  // Always bypass the HTTP cache for JSON API calls — server is the
+  // authoritative source. Without this, browsers heuristic-cache GET
+  // responses (FastAPI sends no Cache-Control headers) and we end up
+  // serving stale state right after a mutating POST. Concrete bug
+  // this prevents: boot calls GET /status (cdm=false), user clicks
+  // Enable → POST /opt-in (stores cdm=true), reload calls GET /status
+  // → browser serves the cached cdm=false → telemetry modal re-opens
+  // forever. `no-store` makes that whole class of bugs impossible.
+  if (!opts.cache) opts.cache = 'no-store';
   const r = await fetch(path, opts);
   if (r.status === 401) {
     // Password-protected install — show login modal and retry after auth

--- a/tests/test_telemetry.py
+++ b/tests/test_telemetry.py
@@ -1161,3 +1161,42 @@ def test_consent_version_bumped_to_2(fresh_tel):
     is caught here — without this, opted-in users would never see
     the re-confirm banner for the new event type."""
     assert fresh_tel._CURRENT_CONSENT_VERSION >= 2
+
+
+# ── Browser cache contract for /api/telemetry/status ─────────────────
+
+
+def test_api_helper_disables_http_cache():
+    """The reported "modal opens after every reload" bug had this
+    sequence:
+
+        boot → GET /status → cdm:false → cached by browser
+        user clicks Enable → POST /opt-in → backend stores cdm:true
+        reload → GET /status → browser serves CACHED cdm:false
+        modal re-opens → forever loop
+
+    Backend was always correct; FastAPI just doesn't set Cache-Control
+    headers on JSON responses, and browsers heuristic-cache them. The
+    fix lives in the JS `api()` helper: every call MUST opt into
+    `cache: 'no-store'` so the browser never replays a stale response.
+
+    This test pins the contract by reading static/index.html and
+    asserting the directive is present in api(). If a future refactor
+    drops it, this test fails loud — much faster than waiting for
+    the modal-loop bug to be reported again.
+    """
+    from pathlib import Path
+    src = (Path(__file__).resolve().parent.parent / "static" / "index.html").read_text(encoding="utf-8")
+    # Locate the api() declaration
+    needle_start = "const api = async (path, opts) =>"
+    idx = src.find(needle_start)
+    assert idx >= 0, "api() declaration not found — was it renamed?"
+    # Scan a reasonable window after it for the no-store opt-in
+    body = src[idx: idx + 2000]
+    assert "no-store" in body, (
+        "api() helper no longer sets cache:'no-store'. "
+        "JSON API calls will be browser-cached, which causes stale-state "
+        "bugs (e.g. the telemetry modal re-opening on every reload). "
+        "Restore the directive in static/index.html."
+    )
+


### PR DESCRIPTION
## Why

Reported: the telemetry **Help improve qwe-qwe?** modal opens on every page reload, even after clicking Enable.

## Root cause

The JS `api()` helper used `fetch`'s default cache mode. FastAPI doesn't set `Cache-Control` headers on JSON responses, so browsers apply heuristic caching to GETs. Sequence:

```
boot     → GET /api/telemetry/status → {consent_decision_made:false} → cached by browser
Enable   → POST /api/telemetry/opt-in → backend stores consent_version=2
reload   → GET /api/telemetry/status → browser serves the CACHED cdm:false
            → checkTelemetryFirstRun() re-opens the modal → forever
```

Backend was always correct — TestClient repro confirms `cdm` flips to `true` the moment `opt_in()` runs. The bug lives entirely on the wire, in browser cache between the two requests.

This is the **same root cause** as PR #22's "opt-in did not persist" verify-step false-positive. That fix was specific to the verify path; this fix is generic and prevents a whole class of "stale UI after POST" bugs.

## Fix

One line in `api()`:

```js
if (!opts.cache) opts.cache = 'no-store';
```

`no-store` (vs `no-cache`) means the response is never kept in cache at all, so it can't poison a future fetch. JSON API responses should never be browser-cached — the server is the authoritative source. Per-call override still works (any call that explicitly sets `opts.cache` is left alone).

## Regression test

`tests/test_telemetry.py::test_api_helper_disables_http_cache` reads `static/index.html` and asserts `api()` contains `"no-store"`. Cheap contract guard — fails loud if a future refactor drops the directive, much faster than waiting for the modal-loop bug to be reported again.

## Test plan

- [x] `pytest tests/test_telemetry.py::test_api_helper_disables_http_cache -v` — pass
- [x] `pytest tests/ -q` — 521 pass, 3 skip, 0 fail (was 520)
- [x] `ruff check .` — clean
- [x] `python scripts/check_js.py` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)