### PR TITLE
feat: per-routine budget caps (v0.21.0)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -183,6 +183,16 @@ Full data inventory + privacy contract: `docs/PRIVACY.md`.
 
 User-facing doc: `docs/COST_TRACKING.md`.
 
+### Routine budget caps (v0.21.0)
+
+Per-routine USD spending caps over a configurable rolling window. Migration `010_routine_budget.sql` adds `budget_usd_cap` (NULL = no cap) and `budget_period_sec` (default 86400) to `scheduled_tasks`.
+
+- `db.get_routine_budget(cron_id)` — returns `{"cap": float, "period_sec": int}` or `None`.
+- `db.get_routine_period_spend(cron_id, period_sec)` — sums `agent_runs.cost_usd` over the window. NULL costs treated as 0 (local/unknown-price models never hit caps).
+- `scheduler._execute_routine` checks budget **after** acquiring the fire lock (atomic w.r.t. concurrent fires). On cap exceeded: calls `db.insert_skipped_run(..., reason="skipped")` then sets `error='budget_exceeded'` on that row, releases the lock, and returns without running `agent.run`.
+- API: `GET /api/routines/{id}/budget` returns `{cap, period_sec, spent}`; `POST /api/routines/{id}/budget` sets or clears the cap. `cap=null` disables enforcement.
+- UI: Routines page shows a color-coded budget chip per routine (green < 80%, orange 80–99%, red >= 100%). Click opens a `prompt()` dialog to set/clear cap + period. `loadRoutineBudgets()` runs alongside `loadRoutineCosts()` on every non-silent Routines view load.
+
 ### Skill import from skills.sh / GitHub (`skills/skill_import.py`)
 
 **Added v0.18.x.** Imports community skills following the agentskills.io SKILL.md spec (YAML frontmatter + markdown body + optional `scripts/` `references/` `assets/`). Two layers:

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@
 </p>
 
 <p align="center">
-  <img src="https://img.shields.io/badge/version-0.19.0-blue" alt="version">
+  <img src="https://img.shields.io/badge/version-0.21.0-blue" alt="version">
   <img src="https://img.shields.io/badge/python-3.11+-green" alt="python">
   <img src="https://img.shields.io/badge/platform-linux%20%7C%20macos%20%7C%20windows-lightgrey" alt="platform">
   <img src="https://img.shields.io/badge/license-MIT-orange" alt="license">

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,3 +1,17 @@
+## v0.21.0 — Per-routine budget caps
+
+- Set a USD spending cap per routine, rolling over a configurable window.
+- When the cap is reached, the next scheduled fire is SKIPPED with
+  `status='skipped'`, `error='budget_exceeded'` in agent_runs — history
+  shows what happened. The routine resumes once spend drops below the cap.
+- UI: Routines page shows a budget chip per routine (green / orange /
+  red based on % of cap). Click to set/clear/edit cap + period.
+- API: `GET /api/routines/{id}/budget` and `POST /api/routines/{id}/budget`.
+- Migration 010 adds `budget_usd_cap` + `budget_period_sec` to
+  `scheduled_tasks`. Pre-existing routines have no cap (default).
+
+---
+
 ## v0.19.0 — Cost tracking & per-session analytics
 
 - New `agent_runs` table replaces `routine_runs`: one row per LLM call site

--- a/config.py
+++ b/config.py
@@ -11,7 +11,7 @@ Embeddings are handled by FastEmbed (ONNX, local, no server needed).
 import os
 from pathlib import Path
 
-VERSION = "0.19.0"
+VERSION = "0.21.0"
 _env = os.environ.get
 
 # ── Data directory (all user data lives here, safe from git) ──

--- a/db.py
+++ b/db.py
@@ -592,3 +592,34 @@ def get_runs_for_routine(cron_id: int, limit: int = 50) -> list[dict]:
             "duration_ms", "status", "error", "result_preview",
             "input_tokens", "output_tokens", "cost_usd", "model", "provider")
     return [dict(zip(cols, r, strict=True)) for r in rows]
+
+
+def get_routine_period_spend(cron_id: int, period_sec: float) -> float:
+    """Sum agent_runs.cost_usd for this cron_id over the last period_sec.
+
+    NULL cost_usd values (pricing unknown) are treated as 0 — they don't
+    contribute to budget burn. This is intentional: a user running a local
+    LLM (cost=0) should never hit a cap; an unknown-price model should not
+    block fires either, but should be obvious in analytics.
+    """
+    import time as _t
+    cutoff = _t.time() - float(period_sec)
+    conn = _get_conn()
+    row = conn.execute(
+        "SELECT COALESCE(SUM(cost_usd), 0.0) FROM agent_runs "
+        "WHERE cron_id = ? AND started_at >= ?",
+        (int(cron_id), cutoff),
+    ).fetchone()
+    return float(row[0] or 0.0)
+
+
+def get_routine_budget(cron_id: int) -> dict | None:
+    """Return {"cap": float, "period_sec": int} or None if no cap set."""
+    conn = _get_conn()
+    row = conn.execute(
+        "SELECT budget_usd_cap, budget_period_sec FROM scheduled_tasks WHERE id=?",
+        (int(cron_id),),
+    ).fetchone()
+    if not row or row[0] is None:
+        return None
+    return {"cap": float(row[0]), "period_sec": int(row[1] or 86400)}

--- a/migrations/010_routine_budget.sql
+++ b/migrations/010_routine_budget.sql
@@ -1,0 +1,15 @@
+-- v0.21.0: per-routine USD budget caps.
+--
+-- budget_usd_cap   — null = no cap (default); positive number = cap in dollars
+-- budget_period_sec — rolling window length, default 86400 (24h)
+--
+-- When set: scheduler sums agent_runs.cost_usd for this cron_id over the
+-- last budget_period_sec; if sum >= cap, the next fire is skipped with
+-- status='skipped', reason='budget_exceeded' in agent_runs (so history
+-- honestly reflects what happened).
+BEGIN;
+
+ALTER TABLE scheduled_tasks ADD COLUMN budget_usd_cap REAL;
+ALTER TABLE scheduled_tasks ADD COLUMN budget_period_sec INTEGER DEFAULT 86400;
+
+COMMIT;

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "qwe-qwe"
-version = "0.19.0"
+version = "0.21.0"
 description = "Business-oriented AI agent — self-hosted, bring your own LLM"
 readme = "README.md"
 license = {text = "MIT"}

--- a/scheduler.py
+++ b/scheduler.py
@@ -944,6 +944,32 @@ def _execute_routine(task_desc: str, routine_name: str, cron_id: int,
             )
         return ""
 
+    # Budget cap check (v0.21.0) — runs after lock acquisition so the check
+    # is atomic w.r.t. concurrent fires on the same thread.
+    budget = db.get_routine_budget(cron_id) if cron_id else None
+    if budget:
+        spent = db.get_routine_period_spend(cron_id, budget["period_sec"])
+        if spent >= budget["cap"]:
+            _log.warning(
+                f"routine #{cron_id}: budget cap ${budget['cap']:.4f} reached "
+                f"(${spent:.4f} spent in last {budget['period_sec']}s) — skipping fire"
+            )
+            try:
+                skip_id = db.insert_skipped_run(
+                    cron_id=cron_id, thread_id=thread_id or "",
+                    scheduled_at=sched_at, reason="skipped",
+                )
+                # Mark the reason via error field for visibility
+                db._get_conn().execute(
+                    "UPDATE agent_runs SET error='budget_exceeded' WHERE id=?",
+                    (skip_id,),
+                )
+                db._get_conn().commit()
+            except Exception as _e:
+                _log.debug(f"budget-skip recording failed: {_e}")
+            lock.release()
+            return ""  # skip the actual agent.run
+
     t0 = time.time()
     reply = ""
     error_msg: str | None = None

--- a/server.py
+++ b/server.py
@@ -2069,6 +2069,38 @@ async def get_routine_runs(cron_id: int, limit: int = 50):
     return db.get_runs_for_routine(cron_id, limit=limit)
 
 
+@app.get("/api/routines/{cron_id}/budget")
+async def get_routine_budget_endpoint(cron_id: int):
+    """Return current budget config + spend for a routine."""
+    b = db.get_routine_budget(cron_id)
+    if not b:
+        return {"cap": None, "period_sec": 86400, "spent": 0.0}
+    spent = db.get_routine_period_spend(cron_id, b["period_sec"])
+    return {"cap": b["cap"], "period_sec": b["period_sec"], "spent": spent}
+
+
+@app.post("/api/routines/{cron_id}/budget")
+async def set_routine_budget_endpoint(cron_id: int, body: dict):
+    """Set or clear a routine's budget cap.
+
+    body: {"cap": float|null, "period_sec": int}
+    cap=null clears the cap (no enforcement).
+    """
+    cap = body.get("cap")
+    period_sec = int(body.get("period_sec") or 86400)
+    if cap is not None:
+        cap = float(cap)
+        if cap < 0:
+            return JSONResponse({"ok": False, "error": "cap must be >= 0"}, status_code=400)
+    conn = db._get_conn()
+    conn.execute(
+        "UPDATE scheduled_tasks SET budget_usd_cap = ?, budget_period_sec = ? WHERE id = ?",
+        (cap, period_sec, int(cron_id)),
+    )
+    conn.commit()
+    return {"ok": True}
+
+
 @app.post("/api/cron/{task_id}/toggle")
 async def toggle_cron(task_id: int, data: dict | None = None):
     """Pause or resume a routine.

--- a/static/index.html
+++ b/static/index.html
@@ -286,6 +286,11 @@ main.canvas { flex: 1; display: flex; flex-direction: column; min-width: 0; }
 .tl-topline-refresh { font-size: 10.5px; font-family: var(--font-mono); background: var(--surface); border: 1px solid var(--line-2); color: var(--fg-3); border-radius: 4px; padding: 2px 8px; cursor: pointer; }
 .tl-topline-refresh:hover { border-color: var(--accent); color: var(--accent); }
 .routine-cost-chip { font-family: var(--font-mono); font-size: 10px; color: var(--fg-3); background: var(--surface-2); border: 1px solid var(--line-2); border-radius: 4px; padding: 1px 6px; margin-left: auto; flex-shrink: 0; }
+.budget-chip { display:inline-flex;align-items:center;padding:2px 8px;margin-left:6px;border-radius:8px;font-size:.8em;cursor:pointer;font-family:var(--font-mono); }
+.budget-chip-green { background:#e7f5e7;color:#1a661a; }
+.budget-chip-orange { background:#fff3cd;color:#b8860b; }
+.budget-chip-red { background:#fde2e2;color:#a32020; }
+.budget-chip-unset { background:var(--surface-2);color:var(--fg-4);border:1px solid var(--line-2); }
 .tl-foot {
   padding: 10px 14px; border-top: 1px solid var(--line);
   display: flex; align-items: center; gap: 8px;
@@ -3461,8 +3466,11 @@ async function loadCron(opts) {
     // every 2s. Full render() would blow them away.
     if (opts.silent) patchThreadHeader();
     else render();
-    // Load per-routine 30d costs on non-silent scheduler view loads
-    if (!opts.silent && state.view === 'scheduler') loadRoutineCosts();
+    // Load per-routine 30d costs + budget caps on non-silent scheduler view loads
+    if (!opts.silent && state.view === 'scheduler') {
+      loadRoutineCosts();
+      loadRoutineBudgets();
+    }
   } catch { state.cronJobs = []; if (!opts.silent) render(); }
   if (!opts.silent) {
     try {
@@ -3493,6 +3501,66 @@ async function loadRoutineCosts() {
   }
   state.routineCosts = costs;
   render();
+}
+
+async function loadRoutineBudgets() {
+  var jobs = state.cronJobs || [];
+  if (!jobs.length) return;
+  var budgets = {};
+  for (var i = 0; i < jobs.length; i++) {
+    var id = jobs[i].id;
+    try {
+      var r = await fetch('/api/routines/' + encodeURIComponent(id) + '/budget');
+      budgets[id] = await r.json();
+    } catch (e) {
+      budgets[id] = null;
+    }
+  }
+  state.routineBudgets = budgets;
+  render();
+}
+
+function renderBudgetChip(cronId, b) {
+  if (!b) return '';
+  if (b.cap === null || b.cap === undefined) {
+    return '<span class="budget-chip budget-chip-unset" data-budget-edit="' + cronId + '" title="No budget cap — click to set one">No cap</span>';
+  }
+  var pct = b.cap > 0 ? Math.min(100, (b.spent / b.cap) * 100) : 0;
+  var periodLabel = b.period_sec === 3600 ? '/hr'
+                  : b.period_sec === 604800 ? '/wk'
+                  : '/day';
+  var color = pct >= 100 ? 'red' : pct >= 80 ? 'orange' : 'green';
+  return '<span class="budget-chip budget-chip-' + color + '" data-budget-edit="' + cronId + '" title="Budget: $' + b.spent.toFixed(4) + ' spent of $' + b.cap.toFixed(2) + periodLabel + ' (' + Math.round(pct) + '%) — click to edit">' +
+    '$' + b.spent.toFixed(2) + ' / $' + b.cap.toFixed(2) + periodLabel +
+  '</span>';
+}
+
+async function openBudgetEditor(cronId) {
+  var r = await fetch('/api/routines/' + encodeURIComponent(cronId) + '/budget');
+  var b = await r.json();
+  var capStr = prompt(
+    'Set budget cap for this routine in USD (leave empty to remove cap):',
+    (b.cap !== null && b.cap !== undefined) ? String(b.cap) : ''
+  );
+  if (capStr === null) return;  // cancelled
+  var periodStr = prompt(
+    'Rolling window in seconds (3600=hour, 86400=day, 604800=week):',
+    String(b.period_sec || 86400)
+  );
+  if (periodStr === null) return;  // cancelled
+  var cap = capStr.trim() === '' ? null : parseFloat(capStr);
+  var period_sec = parseInt(periodStr) || 86400;
+  var resp = await fetch('/api/routines/' + encodeURIComponent(cronId) + '/budget', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ cap: cap, period_sec: period_sec }),
+  });
+  if (resp.ok) {
+    if (typeof loadCron === 'function') loadCron();
+  } else {
+    var err = await resp.json().catch(function() { return {}; });
+    alert('Failed to save budget: ' + (err.error || resp.status));
+  }
 }
 
 // Surgical thread-header swap — used by the routine-thread poll so the
@@ -5118,6 +5186,8 @@ function renderSchedulerView() {
         const rc = state.routineCosts || {};
         const jobCost = rc[j.id] !== undefined ? rc[j.id] : null;
         const costChip = '<span class="routine-cost-chip" title="Cost (last 30 days)">30d: ' + fmtCost(jobCost) + '</span>';
+        const rb = state.routineBudgets || {};
+        const budgetChip = renderBudgetChip(j.id, rb[j.id] !== undefined ? rb[j.id] : null);
         return '<div class="job-card"' + (hasThread ? ' data-open-thread="' + esc(j.threadId) + '"' : '') + ' style="' + cardStyle + '">' +
           '<div class="job-hdr"><div style="flex:1">' +
             '<div class="job-title-row">' +
@@ -5134,8 +5204,8 @@ function renderSchedulerView() {
               '<button class="icon-btn" data-cron="' + esc(j.id) + '" data-cron-act="delete" title="Delete routine (archives the thread)">' + ico('trash', 11) + '</button>' +
             '</div></div>' +
           (j.last
-            ? '<div style="font-size:11px;color:' + (errLast ? 'var(--err)' : 'var(--fg-4)') + ';margin-top:6px;font-family:var(--font-mono);display:flex;align-items:center;gap:8px">last ' + esc(j.last) + ' · ' + (j.runs||0).toLocaleString() + ' runs' + costChip + '</div>'
-            : '<div style="font-size:11px;color:var(--fg-5);margin-top:6px;font-family:var(--font-mono);display:flex;align-items:center;gap:8px">not run yet' + costChip + '</div>') +
+            ? '<div style="font-size:11px;color:' + (errLast ? 'var(--err)' : 'var(--fg-4)') + ';margin-top:6px;font-family:var(--font-mono);display:flex;align-items:center;gap:8px">last ' + esc(j.last) + ' · ' + (j.runs||0).toLocaleString() + ' runs' + costChip + budgetChip + '</div>'
+            : '<div style="font-size:11px;color:var(--fg-5);margin-top:6px;font-family:var(--font-mono);display:flex;align-items:center;gap:8px">not run yet' + costChip + budgetChip + '</div>') +
           // Sparkline of last 20 fires — one dot per attempt, colored
           // by status. Shows missed (server-offline) runs alongside
           // ok/err so users see the real timeline.
@@ -8522,6 +8592,14 @@ function wireEvents() {
       }
     };
   });
+  // Budget chip click — open budget editor dialog.
+  document.querySelectorAll('[data-budget-edit]').forEach(chip => {
+    chip.onclick = async (e) => {
+      e.stopPropagation();
+      await openBudgetEditor(chip.dataset.budgetEdit);
+    };
+  });
+
   // Click on a routine card → switch to that routine's thread, go to chat.
   document.querySelectorAll('[data-open-thread]').forEach(card => {
     card.onclick = async () => {

--- a/tests/test_migrations.py
+++ b/tests/test_migrations.py
@@ -222,3 +222,12 @@ def test_migration_008_copies_legacy_routine_runs(qwe_temp_data_dir):
     conn = db._get_conn()
     rows = conn.execute("SELECT cron_id, thread_id, status, source FROM agent_runs").fetchall()
     assert (1, 't1', 'ok', 'routine') in rows
+
+
+def test_migration_010_adds_budget_columns(qwe_temp_data_dir):
+    import db
+    db._migrated = False
+    conn = db._get_conn()
+    cols = {c[1] for c in conn.execute("PRAGMA table_info(scheduled_tasks)").fetchall()}
+    assert "budget_usd_cap" in cols
+    assert "budget_period_sec" in cols

--- a/tests/test_routine_budget.py
+++ b/tests/test_routine_budget.py
@@ -1,0 +1,69 @@
+"""Tests for per-routine budget caps (v0.21.0)."""
+import time
+import pytest
+
+
+def test_period_spend_empty(qwe_temp_data_dir):
+    import db
+    assert db.get_routine_period_spend(99, 86400) == 0.0
+
+
+def test_period_spend_sums_within_window(qwe_temp_data_dir):
+    import db
+    for cost in (0.10, 0.25, 0.05):
+        rid = db.insert_agent_run(thread_id="t1", cron_id=42, source="routine",
+                                   started_at=time.time(), status="running")
+        db.finalize_agent_run(rid, finished_at=time.time(), duration_ms=10,
+                               status="ok", input_tokens=100, output_tokens=50,
+                               cost_usd=cost)
+    spend = db.get_routine_period_spend(42, 86400)
+    assert abs(spend - 0.40) < 1e-9
+
+
+def test_period_spend_excludes_outside_window(qwe_temp_data_dir):
+    import db
+    long_ago = time.time() - 86400 - 100
+    rid = db.insert_agent_run(thread_id="t1", cron_id=42, source="routine",
+                               started_at=long_ago, status="running")
+    db.finalize_agent_run(rid, finished_at=long_ago, duration_ms=10,
+                           status="ok", input_tokens=100, output_tokens=50,
+                           cost_usd=10.0)
+    assert db.get_routine_period_spend(42, 86400) == 0.0
+
+
+def test_period_spend_null_cost_treated_as_zero(qwe_temp_data_dir):
+    import db
+    rid = db.insert_agent_run(thread_id="t1", cron_id=42, source="routine",
+                               started_at=time.time(), status="running")
+    db.finalize_agent_run(rid, finished_at=time.time(), duration_ms=10,
+                           status="ok", input_tokens=100, output_tokens=50,
+                           cost_usd=None)  # unknown pricing
+    assert db.get_routine_period_spend(42, 86400) == 0.0
+
+
+def test_get_routine_budget_unset(qwe_temp_data_dir):
+    import db
+    conn = db._get_conn()
+    conn.execute(
+        "INSERT INTO scheduled_tasks (name, task, schedule, next_run, enabled) "
+        "VALUES (?, ?, ?, ?, ?)",
+        ("test", "do something", "0 9 * * *", time.time() + 3600, 1),
+    )
+    conn.commit()
+    cron_id = conn.execute("SELECT last_insert_rowid()").fetchone()[0]
+    assert db.get_routine_budget(cron_id) is None
+
+
+def test_get_routine_budget_set(qwe_temp_data_dir):
+    import db
+    conn = db._get_conn()
+    conn.execute(
+        "INSERT INTO scheduled_tasks (name, task, schedule, next_run, enabled, "
+        " budget_usd_cap, budget_period_sec) "
+        "VALUES (?, ?, ?, ?, ?, ?, ?)",
+        ("test", "do something", "0 9 * * *", time.time() + 3600, 1, 1.50, 3600),
+    )
+    conn.commit()
+    cron_id = conn.execute("SELECT last_insert_rowid()").fetchone()[0]
+    b = db.get_routine_budget(cron_id)
+    assert b == {"cap": 1.50, "period_sec": 3600}

--- a/tests/test_routine_budget.py
+++ b/tests/test_routine_budget.py
@@ -130,3 +130,90 @@ def test_scheduler_fires_normally_when_under_budget(qwe_temp_data_dir, mock_llm)
     ).fetchone()
     # Should NOT be skipped — actual run happens (status='ok' or 'err' via mock)
     assert row[0] != "skipped"
+
+
+# ---------------------------------------------------------------------------
+# API endpoint tests
+# ---------------------------------------------------------------------------
+
+def _client():
+    from fastapi.testclient import TestClient
+    import server
+    return TestClient(server.app)
+
+
+def test_get_budget_endpoint_unset(qwe_temp_data_dir):
+    import db
+    conn = db._get_conn()
+    conn.execute(
+        "INSERT INTO scheduled_tasks (name, task, schedule, next_run, enabled) "
+        "VALUES (?, ?, ?, ?, ?)",
+        ("test", "x", "0 9 * * *", time.time() + 3600, 1),
+    )
+    conn.commit()
+    cron_id = conn.execute("SELECT last_insert_rowid()").fetchone()[0]
+
+    client = _client()
+    r = client.get(f"/api/routines/{cron_id}/budget")
+    j = r.json()
+    assert j["cap"] is None
+
+
+def test_set_budget_endpoint_happy(qwe_temp_data_dir):
+    import db
+    conn = db._get_conn()
+    conn.execute(
+        "INSERT INTO scheduled_tasks (name, task, schedule, next_run, enabled) "
+        "VALUES (?, ?, ?, ?, ?)",
+        ("test", "x", "0 9 * * *", time.time() + 3600, 1),
+    )
+    conn.commit()
+    cron_id = conn.execute("SELECT last_insert_rowid()").fetchone()[0]
+
+    client = _client()
+    r = client.post(f"/api/routines/{cron_id}/budget",
+                    json={"cap": 1.50, "period_sec": 3600})
+    assert r.status_code == 200
+
+    # Verify it stuck
+    r2 = client.get(f"/api/routines/{cron_id}/budget")
+    j = r2.json()
+    assert j["cap"] == 1.50
+    assert j["period_sec"] == 3600
+
+
+def test_set_budget_endpoint_clear(qwe_temp_data_dir):
+    import db
+    conn = db._get_conn()
+    conn.execute(
+        "INSERT INTO scheduled_tasks (name, task, schedule, next_run, enabled, budget_usd_cap) "
+        "VALUES (?, ?, ?, ?, ?, ?)",
+        ("test", "x", "0 9 * * *", time.time() + 3600, 1, 5.00),
+    )
+    conn.commit()
+    cron_id = conn.execute("SELECT last_insert_rowid()").fetchone()[0]
+
+    client = _client()
+    r = client.post(f"/api/routines/{cron_id}/budget",
+                    json={"cap": None, "period_sec": 86400})
+    assert r.status_code == 200
+
+    r2 = client.get(f"/api/routines/{cron_id}/budget")
+    assert r2.json()["cap"] is None
+
+
+def test_set_budget_endpoint_rejects_negative(qwe_temp_data_dir):
+    import db
+    conn = db._get_conn()
+    conn.execute(
+        "INSERT INTO scheduled_tasks (name, task, schedule, next_run, enabled) "
+        "VALUES (?, ?, ?, ?, ?)",
+        ("test", "x", "0 9 * * *", time.time() + 3600, 1),
+    )
+    conn.commit()
+    cron_id = conn.execute("SELECT last_insert_rowid()").fetchone()[0]
+
+    client = _client()
+    r = client.post(f"/api/routines/{cron_id}/budget",
+                    json={"cap": -1.0, "period_sec": 86400})
+    assert r.status_code == 400

--- a/tests/test_routine_budget.py
+++ b/tests/test_routine_budget.py
@@ -67,3 +67,66 @@ def test_get_routine_budget_set(qwe_temp_data_dir):
     cron_id = conn.execute("SELECT last_insert_rowid()").fetchone()[0]
     b = db.get_routine_budget(cron_id)
     assert b == {"cap": 1.50, "period_sec": 3600}
+
+
+def test_scheduler_skips_fire_when_budget_exceeded(qwe_temp_data_dir, mock_llm):
+    import db
+    import scheduler
+    conn = db._get_conn()
+    conn.execute(
+        "INSERT INTO scheduled_tasks (name, task, schedule, next_run, enabled, "
+        " budget_usd_cap, budget_period_sec) "
+        "VALUES (?, ?, ?, ?, ?, ?, ?)",
+        ("test", "do something", "0 9 * * *", time.time() + 3600, 1, 0.50, 86400),
+    )
+    conn.commit()
+    cron_id = conn.execute("SELECT last_insert_rowid()").fetchone()[0]
+
+    # Pre-populate $0.60 of spend — over the $0.50 cap
+    for _ in range(2):
+        rid = db.insert_agent_run(thread_id="t1", cron_id=cron_id, source="routine",
+                                   started_at=time.time(), status="running")
+        db.finalize_agent_run(rid, finished_at=time.time(), duration_ms=10,
+                               status="ok", input_tokens=100, output_tokens=50,
+                               cost_usd=0.30)
+
+    scheduler._execute_routine(
+        task_desc="do something", routine_name="test", cron_id=cron_id,
+        thread_id="t1", scheduled_at=time.time(),
+    )
+
+    # Most recent agent_runs row should be a skipped row with budget_exceeded
+    row = db._get_conn().execute(
+        "SELECT status, error FROM agent_runs WHERE cron_id=? "
+        "ORDER BY id DESC LIMIT 1",
+        (cron_id,)
+    ).fetchone()
+    assert row[0] == "skipped"
+    assert "budget" in (row[1] or "").lower()
+
+
+def test_scheduler_fires_normally_when_under_budget(qwe_temp_data_dir, mock_llm):
+    import db
+    import scheduler
+    conn = db._get_conn()
+    conn.execute(
+        "INSERT INTO scheduled_tasks (name, task, schedule, next_run, enabled, "
+        " budget_usd_cap, budget_period_sec) "
+        "VALUES (?, ?, ?, ?, ?, ?, ?)",
+        ("test", "do something", "0 9 * * *", time.time() + 3600, 1, 10.00, 86400),
+    )
+    conn.commit()
+    cron_id = conn.execute("SELECT last_insert_rowid()").fetchone()[0]
+
+    # No spend yet — fire should proceed
+    scheduler._execute_routine(
+        task_desc="do something", routine_name="test", cron_id=cron_id,
+        thread_id="t1", scheduled_at=time.time(),
+    )
+
+    row = db._get_conn().execute(
+        "SELECT status FROM agent_runs WHERE cron_id=? ORDER BY id DESC LIMIT 1",
+        (cron_id,)
+    ).fetchone()
+    # Should NOT be skipped — actual run happens (status='ok' or 'err' via mock)
+    assert row[0] != "skipped"


### PR DESCRIPTION
## Summary

Spec #2 of 3 from the competitor pain-point analysis (NousResearch/hermes-agent#23419 — "Cron jobs burn provider credits without consent or budget cap").

Set a USD spending cap per routine over a rolling time window. When a routine's accumulated spend in the window hits the cap, the next scheduled fire is **skipped** with `status='skipped'` and `error='budget_exceeded'` written to `agent_runs` so the history honestly reflects what happened. The routine auto-resumes once spend drops below the cap (as old fires age out of the window).

## What's new

- Migration 010: `agent_runs.budget_usd_cap` (REAL, nullable) + `agent_runs.budget_period_sec` (INTEGER, default 86400) on `scheduled_tasks`
- `db.get_routine_period_spend(cron_id, period_sec)` — sums `cost_usd` over the window (NULL costs treated as 0)
- `db.get_routine_budget(cron_id)` — returns `{cap, period_sec}` or None
- Scheduler enforcement: budget check inside `_execute_routine`, after lock acquisition but before `agent.run`
- API: `GET /api/routines/{id}/budget` + `POST /api/routines/{id}/budget`
- UI: budget chip per routine on Routines page (green / orange / red by % of cap), click to set/clear/edit cap + period via prompts (MVP — full modal can be a follow-up)

## Stats

- 6 commits, 12 files changed, +441 / -7 lines
- 12 new tests in `tests/test_routine_budget.py` — all green
- No new regressions

## Dependency

This branch was branched from `feat/cost-tracking` (PR #26 — provides `agent_runs.cost_usd`). Merge order: #26 first, then this PR fast-forwards cleanly.

Spec #3 (#27, auto-resume) is independent — they can merge in either order.

## Test plan

- [x] `pytest tests/test_routine_budget.py -v` — 12/12 pass
- [x] `ruff check .` — clean
- [x] `python scripts/check_js.py` — clean
- [x] `python -c "import server; print('ok')"` — clean
- [ ] Smoke: create a routine, set \$0.10 cap with 1-hour period, fire it twice with cheap model — second fire skips, log shows "budget cap reached"
- [ ] Smoke: clear cap via Routines UI → routine fires normally on next slot

## Key design decisions

- **NULL `cost_usd` contributes 0** — local LLMs (lmstudio/ollama) never accidentally hit a cap; unknown-price models don't block fires either, but are obvious in analytics.
- **Soft cap, not hard cap** — the check is "spent >= cap → skip". A run already in flight isn't aborted mid-execution. Hard caps would need mid-run abort logic (out of scope; spec #3's pattern could be reused if needed later).
- **Skip with `status='skipped'`** matches existing scheduler semantics for "fire didn't happen" cases (missed slots, locked threads).

🤖 Generated with [Claude Code](https://claude.com/claude-code)