### PR TITLE
fix: agent silent replies, browser multi-open, skill_creator syntax, pricing & UI bugs

### DIFF
--- a/agent_loop.py
+++ b/agent_loop.py
@@ -779,6 +779,12 @@ def run_loop(
                     messages.append({"role": "user", "content":
                         "[system] STOP. You are in a loop. Give your final answer NOW based on what you already have. Do NOT call any more tools."})
 
+                # Reset nudge counter after a productive tool-call turn so a later
+                # empty-stop can be nudged again (without this, nudge fires at most
+                # once per entire loop even if the agent does 20 more turns of work
+                # between two separate silent-stop events).
+                _nudge_count = 0
+
                 continue  # Next turn
 
             # ── No tool calls — check finish reason ──

--- a/agent_loop.py
+++ b/agent_loop.py
@@ -816,12 +816,19 @@ def run_loop(
 
             # Layer 5: Anti-hedge — ONLY for truly empty replies (thinking but no output)
             # Minimal intervention — don't inject [system] user messages that break model flow.
+            # Also fires after _force_finish: model sometimes responds to the "STOP" nudge with
+            # pure reasoning tokens and no text — without this second chance the user sees nothing.
             _reply_is_empty = len(raw_reply.strip()) == 0 and (len(full_content) > 0 or len(reasoning_content) > 0)
 
-            if not _force_finish and _nudge_count < 1 and _reply_is_empty:
+            if _nudge_count < 1 and _reply_is_empty:
                 _log.info(f"empty reply after thinking — retrying (nudge #{_nudge_count+1})")
-                # Don't inject user message — just let the model try again with context intact
-                messages.append({"role": "assistant", "content": "I need to continue working on this."})
+                # After force_finish the model already received a "STOP" instruction; use a
+                # different nudge that asks for text rather than continuing tool use.
+                if _force_finish:
+                    nudge_text = "Please write your final answer as a text message to the user."
+                else:
+                    nudge_text = "I need to continue working on this."
+                messages.append({"role": "assistant", "content": nudge_text})
                 _nudge_count += 1
                 _nudge_cleanup = True
                 continue

--- a/db.py
+++ b/db.py
@@ -792,18 +792,22 @@ def get_runs_for_thread(thread_id: str, limit: int = 50, offset: int = 0) -> lis
 
 
 def get_thread_totals(thread_id: str) -> dict:
-    """Returns {input_tokens, output_tokens, cost_usd, run_count}."""
+    """Returns {input_tokens, output_tokens, cost_usd, run_count}.
+
+    cost_usd is None (not 0.0) when all runs have NULL cost — callers can
+    distinguish "genuinely zero cost" from "pricing data unavailable".
+    """
     conn = _get_conn()
     row = conn.execute(
         "SELECT COALESCE(SUM(input_tokens),0), COALESCE(SUM(output_tokens),0), "
-        "       COALESCE(SUM(cost_usd),0.0), COUNT(*) "
+        "       SUM(cost_usd), COUNT(*) "
         "FROM agent_runs WHERE thread_id=?",
         (thread_id,),
     ).fetchone()
     return {
         "input_tokens": int(row[0]),
         "output_tokens": int(row[1]),
-        "cost_usd": float(row[2]),
+        "cost_usd": float(row[2]) if row[2] is not None else None,
         "run_count": int(row[3]),
     }
 
@@ -820,13 +824,13 @@ def get_period_totals(
         params.append(source)
     row = conn.execute(
         "SELECT COALESCE(SUM(input_tokens),0), COALESCE(SUM(output_tokens),0), "
-        "       COALESCE(SUM(cost_usd),0.0), COUNT(*) "
+        "       SUM(cost_usd), COUNT(*) "
         f"FROM agent_runs WHERE started_at>=? AND started_at<?{src_clause}",
         params,
     ).fetchone()
     by_src_rows = conn.execute(
         "SELECT source, COALESCE(SUM(input_tokens),0), "
-        "       COALESCE(SUM(output_tokens),0), COALESCE(SUM(cost_usd),0.0), "
+        "       COALESCE(SUM(output_tokens),0), SUM(cost_usd), "
         f"      COUNT(*) FROM agent_runs WHERE started_at>=? AND started_at<?{src_clause} "
         "GROUP BY source",
         params,  # reuse same params (already includes source filter if set)
@@ -835,7 +839,7 @@ def get_period_totals(
         r[0]: {
             "input_tokens": int(r[1]),
             "output_tokens": int(r[2]),
-            "cost_usd": float(r[3]),
+            "cost_usd": float(r[3]) if r[3] is not None else None,
             "run_count": int(r[4]),
         }
         for r in by_src_rows
@@ -845,7 +849,7 @@ def get_period_totals(
         "end_ts": float(end_ts),
         "total_input_tokens": int(row[0]),
         "total_output_tokens": int(row[1]),
-        "total_cost_usd": float(row[2]),
+        "total_cost_usd": float(row[2]) if row[2] is not None else None,
         "run_count": int(row[3]),
         "by_source": by_source,
     }

--- a/db.py
+++ b/db.py
@@ -804,11 +804,15 @@ def get_thread_totals(thread_id: str) -> dict:
         "FROM agent_runs WHERE thread_id=?",
         (thread_id,),
     ).fetchone()
+    run_count = int(row[3])
+    # cost_usd=None means "runs exist but we couldn't price them" (NULL from
+    # unknown-model pricing).  cost_usd=0.0 means "no runs" (definitively zero).
+    cost_usd = float(row[2]) if row[2] is not None else (0.0 if run_count == 0 else None)
     return {
         "input_tokens": int(row[0]),
         "output_tokens": int(row[1]),
-        "cost_usd": float(row[2]) if row[2] is not None else None,
-        "run_count": int(row[3]),
+        "cost_usd": cost_usd,
+        "run_count": run_count,
     }
 
 

--- a/pricing.py
+++ b/pricing.py
@@ -66,6 +66,9 @@ _BUNDLED_FALLBACK: dict[str, dict[str, float]] = {
 
 _LOCAL_PREFIXES = ("lmstudio:", "ollama:", "local:")
 
+# Warn once per process per unknown model so repeated turns don't flood the log.
+_warned_unknown: set[str] = set()
+
 SKIP_MODES = {"embedding", "image_generation", "audio_transcription", "audio_speech"}
 
 _lock = threading.Lock()
@@ -94,13 +97,26 @@ def get_price(model: str, kind: Literal["input", "output"]) -> float | None:
     if model.startswith(_LOCAL_PREFIXES):
         return 0.0
     # 3. Memory / disk cache → 4. Bundled fallback
+    # Try exact name first, then common provider-prefix variants so that a model
+    # stored as "deepseek/deepseek-v4-flash" is also found under
+    # "openrouter/deepseek/deepseek-v4-flash" (and vice-versa).
     pricing = _ensure_loaded()
-    entry = pricing.get(model)
-    if entry and kind in entry:
-        return entry[kind]
-    fb = _BUNDLED_FALLBACK.get(model)
-    if fb and kind in fb:
-        return fb[kind]
+    _candidates = [model]
+    if not model.startswith("openrouter/"):
+        _candidates.append("openrouter/" + model)
+    else:
+        _candidates.append(model[len("openrouter/"):])
+    for _cand in _candidates:
+        entry = pricing.get(_cand)
+        if entry and kind in entry:
+            return entry[kind]
+        fb = _BUNDLED_FALLBACK.get(_cand)
+        if fb and kind in fb:
+            return fb[kind]
+    if model not in _warned_unknown:
+        _warned_unknown.add(model)
+        _log.warning(f"no pricing data for model '{model}' — cost_usd will be NULL. "
+                     f"Set KV pricing_override_{model} or wait for next pricing refresh.")
     return None
 
 

--- a/skills/browser.py
+++ b/skills/browser.py
@@ -3,6 +3,7 @@
 import asyncio
 import concurrent.futures
 import os
+import threading
 import time
 
 DESCRIPTION = "Control a web browser — navigate, click, fill forms, take screenshots"
@@ -364,6 +365,10 @@ _pages: list = []          # all open pages (tabs)
 _network_log = []          # list of {url, method, status, resource_type}
 _console_log: list = []    # list of {level, text, location}
 
+# Serialize browser launch/close to prevent multiple Chrome windows when
+# concurrent spawn_task workers all try to open the browser at the same time.
+_browser_lock = threading.Lock()
+
 
 def _attach_page_listeners(page):
     """Attach network + console listeners to a page."""
@@ -396,36 +401,41 @@ def _attach_page_listeners(page):
     page.on("console", _on_console)
 
 
-_headless_mode = False  # False = visible browser window user can see
+_headless_mode = True  # True = headless (default); False = visible window
 
 
 def _ensure_browser():
-    """Launch Playwright browser if not running."""
+    """Launch Playwright browser if not running. Thread-safe: double-checked lock."""
     global _playwright, _browser, _page, _pages, _network_log, _console_log
+    # Fast path — browser already running (no lock needed)
     if _browser and _browser.is_connected():
         return
-    try:
-        from playwright.sync_api import sync_playwright
-    except ImportError:
-        raise RuntimeError(
-            "Playwright is not installed. Run: pip install playwright && python -m playwright install chromium"
+    with _browser_lock:
+        # Re-check inside lock: another thread may have launched while we waited
+        if _browser and _browser.is_connected():
+            return
+        try:
+            from playwright.sync_api import sync_playwright
+        except ImportError:
+            raise RuntimeError(
+                "Playwright is not installed. Run: pip install playwright && python -m playwright install chromium"
+            )
+        _playwright = sync_playwright().start()
+        _browser = _playwright.chromium.launch(
+            headless=_headless_mode,
+            args=["--no-sandbox", "--disable-dev-shm-usage"],
         )
-    _playwright = sync_playwright().start()
-    _browser = _playwright.chromium.launch(
-        headless=_headless_mode,
-        args=["--no-sandbox", "--disable-dev-shm-usage"],
-    )
-    context = _browser.new_context(
-        viewport={"width": 1280, "height": 800},
-        user_agent="Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36",
-        ignore_https_errors=True,  # accept self-signed certs (e.g. localhost HTTPS dev servers)
-    )
-    _page = context.new_page()
-    _pages = [_page]
-    _network_log = []
-    _console_log = []
+        context = _browser.new_context(
+            viewport={"width": 1280, "height": 800},
+            user_agent="Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36",
+            ignore_https_errors=True,  # accept self-signed certs (e.g. localhost HTTPS dev servers)
+        )
+        _page = context.new_page()
+        _pages = [_page]
+        _network_log = []
+        _console_log = []
 
-    _attach_page_listeners(_page)
+        _attach_page_listeners(_page)
 
 
 def _close_browser():
@@ -501,9 +511,16 @@ def _execute_impl(name: str, args: dict) -> str:
             global _headless_mode
             visible = args.get("visible", True)
             new_mode = not visible  # headless is the opposite of visible
-            if new_mode != _headless_mode:
-                _headless_mode = new_mode
-                _close_browser()  # restart with new mode on next call
+            with _browser_lock:
+                if new_mode == _headless_mode and _browser and _browser.is_connected():
+                    # Already in the requested mode with a running browser — no-op.
+                    # This is the common case when multiple spawn_task workers all
+                    # call browser_set_visible(True) on an already-visible browser:
+                    # only the first one opens Chrome; the rest reuse it.
+                    return f"Browser already in {'visible' if visible else 'headless'} mode (reusing existing window)."
+                if new_mode != _headless_mode:
+                    _headless_mode = new_mode
+                    _close_browser()  # restart with new mode on next call
             # Telemetry: track first time the user enables visible mode in
             # this session. We only emit on visible=True — toggling back to
             # headless is the default state and not a "feature use".

--- a/skills/skill_creator.py
+++ b/skills/skill_creator.py
@@ -1170,6 +1170,106 @@ def _fix_indentation(code: str) -> str:
     return "\n".join(fixed)
 
 
+def _fix_elif_body_indent(code: str) -> str:
+    """Fix the LLM anti-pattern where elif/if branch bodies are at the elif's own indent.
+
+    Local models often emit:
+
+        elif name == "x":
+            pass                  ← _fix_empty_blocks added this (body was empty)
+        real_code()               ← at elif_indent, NOT inside the branch
+        return "result"           ← at elif_indent — breaks the if/elif chain
+
+        elif name == "y":         ← SyntaxError: elif after non-if statements
+
+    This function detects that pattern (elif/if followed by pass + body at wrong
+    indent) and re-indents the real body to be INSIDE the branch (+4).
+    """
+    lines = code.split("\n")
+    out: list[str] = []
+    i = 0
+
+    # Pattern that marks the start of a tool-dispatch branch at any indent
+    _branch_re = re.compile(r'^( *)(el)?if\s+name\s*==\s*.+:\s*$')
+
+    while i < len(lines):
+        line = lines[i]
+        m = _branch_re.match(line)
+        if not m:
+            out.append(line)
+            i += 1
+            continue
+
+        elif_indent = len(m.group(1))
+        body_indent = elif_indent + 4
+
+        # Peek at next non-blank line after the branch header
+        j = i + 1
+        while j < len(lines) and not lines[j].strip():
+            j += 1
+
+        # Must be `pass` at body_indent
+        if not (j < len(lines)
+                and lines[j].strip() == "pass"
+                and len(lines[j]) - len(lines[j].lstrip()) == body_indent):
+            out.append(line)
+            i += 1
+            continue
+
+        # Peek at line after `pass`
+        k = j + 1
+        while k < len(lines) and not lines[k].strip():
+            k += 1
+
+        if k >= len(lines):
+            out.append(line)
+            i += 1
+            continue
+
+        after_indent = len(lines[k]) - len(lines[k].lstrip())
+        after_stripped = lines[k].strip()
+
+        # Bad pattern: code after pass is at elif_indent (same level as branch header)
+        # AND it is NOT a new tool-dispatch branch.
+        is_at_same_level = (after_indent == elif_indent)
+        is_new_branch = bool(_branch_re.match(lines[k]))
+        if not (is_at_same_level and not is_new_branch):
+            out.append(line)
+            i += 1
+            continue
+
+        # ── Bad pattern confirmed. Repair it. ──
+        # 1. Emit the branch header line.
+        out.append(line)
+        # 2. Emit any blank lines between the header and the pass (unusual but safe).
+        for b in range(i + 1, j):
+            out.append(lines[b])
+        # 3. Skip the spurious `pass` (j) — we'll give the branch a real body.
+        i = k  # jump straight to the real body
+
+        # 4. Collect and re-indent the real body until the next tool-dispatch
+        #    branch (or else:) at elif_indent.
+        while i < len(lines):
+            curr = lines[i]
+            curr_stripped = curr.strip()
+            if not curr_stripped:
+                out.append(curr)
+                i += 1
+                continue
+            curr_indent = len(curr) - len(curr.lstrip())
+            # Stop at the next elif/if that dispatches on `name` at the same level,
+            # or at a bare `else:` (catch-all branch).
+            if curr_indent == elif_indent:
+                if _branch_re.match(curr) or curr_stripped.rstrip() == "else:":
+                    break
+            # Re-indent by +4 to place inside the branch body.
+            out.append(" " * (curr_indent + 4) + curr_stripped)
+            i += 1
+        # `continue` so the outer while re-processes `lines[i]` (the next branch).
+
+    return "\n".join(out)
+
+
 def _fix_empty_blocks(code: str) -> str:
     """Add 'pass' after empty if/elif/else/try/except blocks."""
     lines = code.split("\n")
@@ -1529,6 +1629,7 @@ def _run_pipeline(skill_name: str, description: str, target: Path, task_id: int 
                 custom_code = _extract_code(custom_raw)
                 custom_code = _fix_indentation(custom_code)
                 custom_code = _fix_empty_blocks(custom_code)
+                custom_code = _fix_elif_body_indent(custom_code)
                 # Defensive post-process: even with the prompt fix,
                 # small models sometimes still emit `elif` first when
                 # they're supposed to start with `if`. If our body is
@@ -1591,8 +1692,10 @@ def _run_pipeline(skill_name: str, description: str, target: Path, task_id: int 
                 ast.parse(code)
             except SyntaxError as e:
                 _log.warning(f"[{skill_name}] syntax error on attempt {attempt}: {e}")
-                # Try one more fix: ensure all blocks have content
+                # Try one more fix: ensure all blocks have content and that
+                # LLM-generated elif branches have their bodies properly indented.
                 execute_body = _fix_empty_blocks(execute_body)
+                execute_body = _fix_elif_body_indent(execute_body)
                 code = SKILL_TEMPLATE.format(
                     docstring_block=docstring_block,
                     short_description_repr=short_desc_repr,

--- a/static/index.html
+++ b/static/index.html
@@ -6859,17 +6859,15 @@ function wireAutoResumeCard() {
     };
     btn.disabled = true; btn.textContent = 'Saving…';
     let ok = true;
-    for (const [k, v] of Object.entries(updates)) {
-      try {
-        const r = await fetch('/api/settings/' + k, {
-          method: 'POST',
-          headers: { 'Content-Type': 'application/json' },
-          body: JSON.stringify({ value: v }),
-        });
-        if (!r.ok) ok = false;
-        else if (state.allSettings && state.allSettings[k]) state.allSettings[k].value = v;
-      } catch { ok = false; }
-    }
+    try {
+      // POST /api/settings accepts {key: value, ...} — one call for all keys
+      const r = await api('/api/settings', { method: 'POST', body: updates });
+      if (r && r.results) {
+        for (const [k, v] of Object.entries(updates)) {
+          if (state.allSettings && state.allSettings[k]) state.allSettings[k].value = v;
+        }
+      } else { ok = false; }
+    } catch { ok = false; }
     toast(ok ? 'auto-resume settings saved' : 'some settings failed to save', ok ? 'ok' : 'err');
     btn.disabled = false; btn.textContent = 'Save';
   };

--- a/static/index.html
+++ b/static/index.html
@@ -2438,23 +2438,28 @@ const handleWsMessage = (msg) => {
       if (typeof msg.thinking === 'string' && msg.thinking) s.thinking = msg.thinking;
       if (Array.isArray(msg.tools) && msg.tools.length) {
         // Server's reply.tools is result.tool_calls_made — a list of name
-        // strings ("shell", "self_config", ...). Older code mapped each
-        // string through ``tc.name`` which is undefined on a string, so
-        // every reloaded tool row rendered as name="tool". Treat strings
-        // as the name directly; preserve the object shape if the server
-        // ever upgrades to sending richer per-call dicts.
-        s.tools = msg.tools.map((tc, i) => {
-          if (typeof tc === 'string') {
-            return { id: tc + '-final-' + i, name: tc, status: 'ok', args: {}, result: '' };
-          }
-          return {
-            id: tc.id || ((tc.name || 'tool') + '-final-' + i),
-            name: tc.name || 'tool',
-            status: tc.error ? 'err' : 'ok',
-            args: tc.args || tc.input || {},
-            result: tc.result || tc.output || '',
-          };
-        });
+        // strings ("shell", "self_config", ...). During streaming, s.tools was
+        // populated by tool_call/tool_end events that carry actual args + results.
+        // Replacing s.tools here with empty-result stubs would wipe that data.
+        // Only replace when the server sends rich objects (future upgrade path);
+        // when it's all strings, keep the streaming-populated array so tool
+        // results remain visible to the user after the turn completes.
+        const allStrings = msg.tools.every(tc => typeof tc === 'string');
+        if (!allStrings) {
+          s.tools = msg.tools.map((tc, i) => {
+            if (typeof tc === 'string') {
+              return { id: tc + '-final-' + i, name: tc, status: 'ok', args: {}, result: '' };
+            }
+            return {
+              id: tc.id || ((tc.name || 'tool') + '-final-' + i),
+              name: tc.name || 'tool',
+              status: tc.error ? 'err' : 'ok',
+              args: tc.args || tc.input || {},
+              result: tc.result || tc.output || '',
+            };
+          });
+        }
+        // else: keep s.tools as-is — results from streaming events are preserved
       }
       const split = splitFiles(msg.files);
       if (split.images.length) s._images = (s._images || []).concat(split.images);

--- a/static/index.html
+++ b/static/index.html
@@ -692,6 +692,7 @@ details.tool[open] > summary .tool-result { color: var(--fg-4); }
 }
 .codeblock code { font-family: inherit; }
 .action-bar { display: flex; gap: 2px; margin-top: 12px; opacity: 0.6; }
+.msg-stats { font-family: var(--font-mono); font-size: 10px; color: var(--fg-4); margin-top: 6px; display: flex; gap: 8px; flex-wrap: wrap; }
 
 /* Composer */
 .composer { padding: 14px 0 20px; background: var(--bg); position: sticky; bottom: 0; }
@@ -4406,6 +4407,20 @@ function renderMessage(m) {
   // summary is the first thing visible, then reasoning, then the prose
   // reply. Previous order (thinking → body → tools) buried the concrete
   // actions under a wall of reasoning text.
+  // Per-message token / speed stats — shown for completed assistant turns.
+  // Data lives in m._meta (loaded from DB) or m._replyMeta (set live on streaming msg).
+  const _sm = (!isUser && !m.streaming) ? (m._meta || m._replyMeta || {}) : null;
+  const _smIn  = _sm && (_sm.prompt_tokens || 0);
+  const _smOut = _sm && (_sm.tokens || 0);
+  const _smMs  = _sm && (_sm.duration_ms || 0);
+  const _smTps = _sm && (_sm.tok_per_sec || 0);
+  const msgStats = (_sm && (_smIn || _smOut))
+    ? '<div class="msg-stats">' +
+        '<span title="Input / output tokens">↑ ' + fmtTokens(_smIn) + ' → ↓ ' + fmtTokens(_smOut) + '</span>' +
+        (_smTps ? '<span title="Generation speed">' + Math.round(_smTps) + ' tok/s</span>' : '') +
+        (_smMs  ? '<span title="Turn duration">' + (_smMs >= 1000 ? (_smMs/1000).toFixed(1) + 's' : _smMs + 'ms') + '</span>' : '') +
+      '</div>'
+    : '';
   // Interrupted marker — shown when meta.interrupted is set on the row.
   // meta may arrive as a JSON string from the server wire format; parse defensively.
   let msgMeta = {};
@@ -4418,7 +4433,7 @@ function renderMessage(m) {
         (msgMeta.run_id ? '<span class="im-runid">run #' + esc(msgMeta.run_id) + '</span>' : '') +
       '</div>'
     : '';
-  return '<section class="msg' + (isUser ? ' user' : '') + (isInterrupted ? ' msg-interrupted' : '') + '" data-msg-id="' + esc(m.id) + '">' + head + tools + thinking + body + interruptedMarker + images + files + actions + '</section>';
+  return '<section class="msg' + (isUser ? ' user' : '') + (isInterrupted ? ' msg-interrupted' : '') + '" data-msg-id="' + esc(m.id) + '">' + head + tools + thinking + body + interruptedMarker + images + files + msgStats + actions + '</section>';
 }
 
 function renderChatView() {

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -38,6 +38,13 @@ def qwe_temp_data_dir(monkeypatch):
     tmp_root = Path(tempfile.mkdtemp(prefix="castor_pytest_"))
     monkeypatch.setenv("CASTOR_DATA_DIR", str(tmp_root))
 
+    # Prevent config._migrate_data() from copying the developer's real castor.db
+    # into the test sandbox. Both migration helpers check for a marker file and
+    # skip when it's present. Writing them before any module reload means the
+    # helpers are no-ops for every test that uses this fixture.
+    (tmp_root / ".migrated_v2").write_text("test skip\n")
+    (tmp_root / ".migrated_from_qwe_qwe").write_text("test skip\n")
+
     # Close any stale DB connection before reload
     if "db" in sys.modules:
         try:

--- a/tests/test_db_protection.py
+++ b/tests/test_db_protection.py
@@ -78,10 +78,20 @@ def test_check_and_restore_detects_corruption(qwe_temp_data_dir):
     import db
     import config
     db._get_conn()
+    # Close the connection properly before corrupting so the WAL is flushed/closed
+    conn = db._local.conn
+    if conn is not None:
+        conn.close()
     db._local.conn = None
     db._migrated = False
     db._integrity_checked = False
-    Path(config.DB_PATH).write_bytes(b"THIS IS NOT A SQLITE DATABASE" * 100)
+    db_path = Path(config.DB_PATH)
+    db_path.write_bytes(b"THIS IS NOT A SQLITE DATABASE" * 100)
+    # Remove WAL/SHM sidecars so SQLite cannot recover from them and mask corruption
+    for ext in ("-wal", "-shm"):
+        sidecar = db_path.parent / (db_path.name + ext)
+        if sidecar.exists():
+            sidecar.unlink()
     assert db.check_and_restore() is False  # no backup → returns False
 
 
@@ -92,13 +102,23 @@ def test_check_and_restore_restores_from_backup(qwe_temp_data_dir):
     db.kv_set("canary", "alive")
     db.take_backup("before_corrupt")
 
+    # Close the connection properly before corrupting so the WAL is flushed/closed
+    conn = db._local.conn
+    if conn is not None:
+        conn.close()
     # Reset ALL module-level state so check_and_restore() fires again
     db._local.conn = None
     db._migrated = False
     db._integrity_checked = False  # critical: without this the guard skips the check
 
-    # Corrupt the database
-    Path(config.DB_PATH).write_bytes(b"CORRUPTED" * 200)
+    # Corrupt the database and remove WAL/SHM sidecars so SQLite cannot recover
+    # from them and mask the corruption before check_and_restore() probes
+    db_path = Path(config.DB_PATH)
+    db_path.write_bytes(b"CORRUPTED" * 200)
+    for ext in ("-wal", "-shm"):
+        sidecar = db_path.parent / (db_path.name + ext)
+        if sidecar.exists():
+            sidecar.unlink()
 
     result = db.check_and_restore()
     assert result is True

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -42,6 +42,10 @@ def _integration_env():
     original = os.environ.get("CASTOR_DATA_DIR")
     tmp_root = Path(tempfile.mkdtemp(prefix="qwe_int_test_"))
     os.environ["CASTOR_DATA_DIR"] = str(tmp_root)
+    # Prevent config._migrate_data() from copying the developer's real castor.db
+    # into the test sandbox before any module reload happens.
+    (tmp_root / ".migrated_v2").write_text("test skip\n")
+    (tmp_root / ".migrated_from_qwe_qwe").write_text("test skip\n")
     _reload_core()
     try:
         yield tmp_root

--- a/tests/test_ws_attachments.py
+++ b/tests/test_ws_attachments.py
@@ -349,6 +349,42 @@ def test_reload_path_runs_meta_files_through_splitfiles():
     )
 
 
+def test_reply_event_preserves_streaming_tool_results():
+    """Reported: skill runs and returns data, but user can't see its output.
+
+    Root cause: when the `reply` WS event arrives, the handler replaces
+    s.tools with msg.tools.map(...) where every tool gets result:''. Since
+    server sends result.tool_calls_made — a list of name strings — this
+    wipes the args + results that tool_call/tool_end events accumulated
+    during streaming.  User sees empty tool bubbles even though the skill
+    ran successfully.
+
+    Fix: when msg.tools is all strings (allStrings check), skip the replace
+    so the streaming-populated s.tools is preserved.
+
+    This test pins that contract by asserting the allStrings guard exists
+    in the reply event handler.
+    """
+    from pathlib import Path
+    src = (Path(__file__).resolve().parent.parent / "static" / "index.html").read_text(encoding="utf-8")
+    # Anchor on the comment that documents this exact contract
+    anchor = "keep s.tools as-is — results from streaming events are preserved"
+    assert anchor in src, (
+        "reply event handler no longer guards against wiping streaming tool results. "
+        "When msg.tools is a list of name strings (as server always sends), replacing "
+        "s.tools sets result:'' on every tool bubble — erasing data the user should see. "
+        "Restore the allStrings guard in static/index.html's 'reply' event handler."
+    )
+    # Also assert the allStrings check itself is present near the anchor
+    idx = src.find(anchor)
+    window = src[max(0, idx - 600): idx + 50]
+    assert "allStrings" in window, (
+        "allStrings variable not found near the streaming-results guard comment. "
+        "The guard must check that all msg.tools entries are strings before skipping "
+        "the s.tools replacement."
+    )
+
+
 def test_soul_trait_description_uses_low_high_not_raw_object():
     """Reported: Settings → Soul shows '[object Object]' next to every
     built-in trait (humor, honesty, etc.).


### PR DESCRIPTION
## Summary

Nine bug fixes across the agent loop, browser skill, skill creator, pricing, and Web UI — all diagnosed from live session logs.

### Agent loop

- **Silent reply after `_force_finish`** (`agent_loop.py`): anti-hedge nudge was gated on `not _force_finish`, so when loop-detection triggered and the model responded with only thinking tokens, the user saw nothing. Nudge now also fires after `_force_finish` with a softer prompt.

- **Nudge counter never reset** (`agent_loop.py`): `_nudge_count` was never cleared within a turn. If a nudge fired at turn 3 and the agent did 12 more productive tool-call turns, another silent stop at turn 16 got no second nudge. Counter now resets to 0 after every productive (tool-call) turn.

### Browser skill

- **Multiple Chrome windows from `spawn_task` workers** (`skills/browser.py`):
  - `_headless_mode = False` was the module default → every `_ensure_browser()` launched a *visible* Chrome, even background workers. Default corrected to `True`.
  - No thread-safety in `_ensure_browser()`: concurrent workers could both see `_browser is None` and both launch Chrome. Added double-checked locking via `_browser_lock`.
  - `browser_set_visible` now short-circuits with "reusing existing window" if browser is already in requested mode.

### Skill creator

- **LLM-generated `elif` bodies at wrong indent** (`skills/skill_creator.py`): local models emit branch bodies at the `elif`'s own indent level (not inside it), causing `SyntaxError`. Added `_fix_elif_body_indent()` that detects the pattern, removes spurious `pass`, and re-indents the body by +4. Verified against three `linkedin_lead_gen` debug files.

### Pricing & DB

- **OpenRouter models showing `$0.0000`** (`pricing.py`): LiteLLM stores them as `openrouter/<model>` but agent stores `<model>`. `get_price()` now tries both variants. Added once-per-model WARNING log.

- **`NULL` cost shown as `$0.0000`** (`db.py`): `COALESCE(SUM(cost_usd), 0.0)` was masking unknown-price runs. Now propagates `NULL`; UI renders `—`. `get_thread_totals` returns `0.0` only when there are genuinely no runs.

### Web UI

- **Streaming tool results wiped on `reply` event**: `reply` WS event was replacing `s.tools` with stub strings, erasing results from streaming. Added `allStrings` guard.

- **"Some settings failed to save"** in auto-resume section: Save button POSTed to `/api/settings/<key>` (doesn't exist). Fixed to use `POST /api/settings` with batch body.

- **Per-message token stats**: assistant messages now show `↑ 5.5k → ↓ 419 · 127 tok/s · 2.1s`.

### Tests

- **`config._migrate_data()` polluting test sandboxes**: pre-write `.migrated_v2` / `.migrated_from_qwe_qwe` marker files before each module reload in fixtures.

## Test plan

- [ ] `pytest tests/ -q` — 819 pass
- [ ] Long task (>5 rounds) ends with a visible reply
- [ ] Two concurrent `spawn_task` browser workers → only one Chrome window
- [ ] OpenRouter model cost column shows real value or `—`, not `$0.0000`
- [ ] `create_skill` with two custom tools → file parses and smoke-tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)